### PR TITLE
stBTC -> acreBTC

### DIFF
--- a/solidity/contracts/acreBTC.sol
+++ b/solidity/contracts/acreBTC.sol
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "@thesis-co/solidity-contracts/contracts/token/IReceiveApproval.sol";
+
+import "./PausableOwnable.sol";
+import "./lib/ERC4626Fees.sol";
+import "./interfaces/IDispatcher.sol";
+import {ZeroAddress} from "./utils/Errors.sol";
+
+/// @title acreBTC
+/// @notice This contract implements the ERC-4626 tokenized vault standard. By
+///         staking tBTC, users acquire a liquid staking token called acreBTC,
+///         commonly referred to as "shares".
+///         Users have the flexibility to redeem acreBTC, enabling them to
+///         withdraw their deposited tBTC along with the accrued yield.
+/// @dev ERC-4626 is a standard to optimize and unify the technical parameters
+///      of yield-bearing vaults. This contract facilitates the minting and
+///      burning of shares (acreBTC), which are represented as standard ERC20
+///      tokens, providing a seamless exchange with tBTC tokens.
+// slither-disable-next-line missing-inheritance
+contract acreBTC is ERC4626Fees, PausableOwnable {
+    using SafeERC20 for IERC20;
+
+    /// Dispatcher contract that routes tBTC from acreBTC to a given allocation
+    /// contract and back.
+    IDispatcher public dispatcher;
+
+    /// Address of the treasury wallet, where fees should be transferred to.
+    address public treasury;
+
+    /// Minimum amount for a single deposit operation. The value should be set
+    /// low enough so the deposits routed through Bitcoin Depositor contract won't
+    /// be rejected. It means that minimumDepositAmount should be lower than
+    /// tBTC protocol's depositDustThreshold reduced by all the minting fees taken
+    /// before depositing in the Acre contract.
+    uint256 public minimumDepositAmount;
+
+    /// Entry fee basis points applied to entry fee calculation.
+    uint256 public entryFeeBasisPoints;
+
+    /// Exit fee basis points applied to exit fee calculation.
+    uint256 public exitFeeBasisPoints;
+
+    /// Emitted when the treasury wallet address is updated.
+    /// @param oldTreasury Address of the old treasury wallet.
+    /// @param newTreasury Address of the new treasury wallet.
+    event TreasuryUpdated(address oldTreasury, address newTreasury);
+
+    /// Emitted when deposit parameters are updated.
+    /// @param minimumDepositAmount New value of the minimum deposit amount.
+    event MinimumDepositAmountUpdated(uint256 minimumDepositAmount);
+
+    /// Emitted when the dispatcher contract is updated.
+    /// @param oldDispatcher Address of the old dispatcher contract.
+    /// @param newDispatcher Address of the new dispatcher contract.
+    event DispatcherUpdated(address oldDispatcher, address newDispatcher);
+
+    /// Emitted when the entry fee basis points are updated.
+    /// @param entryFeeBasisPoints New value of the fee basis points.
+    event EntryFeeBasisPointsUpdated(uint256 entryFeeBasisPoints);
+
+    /// Emitted when the exit fee basis points are updated.
+    /// @param exitFeeBasisPoints New value of the fee basis points.
+    event ExitFeeBasisPointsUpdated(uint256 exitFeeBasisPoints);
+
+    /// Reverts if the amount is less than the minimum deposit amount.
+    /// @param amount Amount to check.
+    /// @param min Minimum amount to check 'amount' against.
+    error LessThanMinDeposit(uint256 amount, uint256 min);
+
+    /// Reverts if the address is disallowed.
+    error DisallowedAddress();
+
+    /// Reverts if the fee basis points exceed the maximum value.
+    error ExceedsMaxFeeBasisPoints();
+
+    /// Reverts if the treasury address is the same.
+    error SameTreasury();
+
+    /// Reverts if the dispatcher address is the same.
+    error SameDispatcher();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(IERC20 asset, address _treasury) public initializer {
+        __ERC4626_init(asset);
+        __ERC20_init("Acre Staked Bitcoin", "acreBTC"); // TODO: Confirm name
+        __PausableOwnable_init(msg.sender, msg.sender);
+
+        if (address(_treasury) == address(0)) {
+            revert ZeroAddress();
+        }
+        treasury = _treasury;
+
+        minimumDepositAmount = 0.001 * 1e18; // 0.001 tBTC
+        entryFeeBasisPoints = 0;
+        exitFeeBasisPoints = 25; // 25 bps == 0.25%
+    }
+
+    /// @notice Updates treasury wallet address.
+    /// @param newTreasury New treasury wallet address.
+    function updateTreasury(address newTreasury) external onlyOwner {
+        if (newTreasury == address(0)) {
+            revert ZeroAddress();
+        }
+        if (newTreasury == address(this)) {
+            revert DisallowedAddress();
+        }
+        if (newTreasury == treasury) {
+            revert SameTreasury();
+        }
+
+        emit TreasuryUpdated(treasury, newTreasury);
+
+        treasury = newTreasury;
+    }
+
+    /// @notice Updates minimum deposit amount.
+    /// @param newMinimumDepositAmount New value of the minimum deposit amount. It
+    ///        is the minimum amount for a single deposit operation.
+    function updateMinimumDepositAmount(
+        uint256 newMinimumDepositAmount
+    ) external onlyOwner {
+        minimumDepositAmount = newMinimumDepositAmount;
+
+        emit MinimumDepositAmountUpdated(newMinimumDepositAmount);
+    }
+
+    /// @notice Updates the dispatcher contract and gives it an unlimited
+    ///         allowance to transfer deposited tBTC.
+    /// @param newDispatcher Address of the new dispatcher contract.
+    function updateDispatcher(IDispatcher newDispatcher) external onlyOwner {
+        if (address(newDispatcher) == address(0)) {
+            revert ZeroAddress();
+        }
+        if (address(newDispatcher) == address(dispatcher)) {
+            revert SameDispatcher();
+        }
+
+        address oldDispatcher = address(dispatcher);
+
+        emit DispatcherUpdated(oldDispatcher, address(newDispatcher));
+        dispatcher = newDispatcher;
+
+        if (oldDispatcher != address(0)) {
+            // Setting allowance to zero for the old dispatcher
+            IERC20(asset()).forceApprove(oldDispatcher, 0);
+        }
+
+        // Setting allowance to max for the new dispatcher
+        IERC20(asset()).forceApprove(address(dispatcher), type(uint256).max);
+    }
+
+    /// @notice Update the entry fee basis points.
+    /// @param newEntryFeeBasisPoints New value of the fee basis points.
+    function updateEntryFeeBasisPoints(
+        uint256 newEntryFeeBasisPoints
+    ) external onlyOwner {
+        if (newEntryFeeBasisPoints > _BASIS_POINT_SCALE) {
+            revert ExceedsMaxFeeBasisPoints();
+        }
+        entryFeeBasisPoints = newEntryFeeBasisPoints;
+
+        emit EntryFeeBasisPointsUpdated(newEntryFeeBasisPoints);
+    }
+
+    /// @notice Update the exit fee basis points.
+    /// @param newExitFeeBasisPoints New value of the fee basis points.
+    function updateExitFeeBasisPoints(
+        uint256 newExitFeeBasisPoints
+    ) external onlyOwner {
+        if (newExitFeeBasisPoints > _BASIS_POINT_SCALE) {
+            revert ExceedsMaxFeeBasisPoints();
+        }
+        exitFeeBasisPoints = newExitFeeBasisPoints;
+
+        emit ExitFeeBasisPointsUpdated(newExitFeeBasisPoints);
+    }
+
+    /// @notice Calls `receiveApproval` function on spender previously approving
+    ///         the spender to withdraw from the caller multiple times, up to
+    ///         the `value` amount. If this function is called again, it
+    ///         overwrites the current allowance with `value`. Reverts if the
+    ///         approval reverted or if `receiveApproval` call on the spender
+    ///         reverted.
+    /// @dev If the `value` is set to `type(uint256).max` then
+    ///      `transferFrom` and `burnFrom` will not reduce an allowance.
+    /// @param spender The address which will spend the funds.
+    /// @param value The amount of tokens to be spent.
+    /// @param extraData Additional data.
+    /// @return True if both approval and `receiveApproval` calls succeeded.
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes memory extraData
+    ) external returns (bool) {
+        if (approve(spender, value)) {
+            IReceiveApproval(spender).receiveApproval(
+                msg.sender,
+                value,
+                address(this),
+                extraData
+            );
+            return true;
+        }
+        return false;
+    }
+
+    /// @notice Mints shares to receiver by depositing exactly amount of
+    ///         tBTC tokens.
+    /// @dev Takes into account a deposit parameter, minimum deposit amount,
+    ///      which determines the minimum amount for a single deposit operation.
+    ///      The amount of the assets has to be pre-approved in the tBTC
+    ///      contract.
+    /// @param assets Approved amount of tBTC tokens to deposit. This includes
+    ///               treasury fees for staking tBTC.
+    /// @param receiver The address to which the shares will be minted.
+    /// @return Minted shares adjusted for the fees taken by the treasury.
+    function deposit(
+        uint256 assets,
+        address receiver
+    ) public override returns (uint256) {
+        if (assets < minimumDepositAmount) {
+            revert LessThanMinDeposit(assets, minimumDepositAmount);
+        }
+
+        return super.deposit(assets, receiver);
+    }
+
+    /// @notice Mints shares to receiver by depositing tBTC tokens.
+    /// @dev Takes into account a deposit parameter, minimum deposit amount,
+    ///      which determines the minimum amount for a single deposit operation.
+    ///      The amount of the assets has to be pre-approved in the tBTC
+    ///      contract.
+    ///      The msg.sender is required to grant approval for the transfer of a
+    ///      certain amount of tBTC, and in addition, approval for the associated
+    ///      fee. Specifically, the total amount to be approved (amountToApprove)
+    ///      should be equal to the sum of the deposited amount and the fee.
+    ///      To determine the total assets amount necessary for approval
+    ///      corresponding to a given share amount, use the `previewMint` function.
+    /// @param shares Amount of shares to mint.
+    /// @param receiver The address to which the shares will be minted.
+    /// @return assets Used assets to mint shares.
+    function mint(
+        uint256 shares,
+        address receiver
+    ) public override returns (uint256 assets) {
+        if ((assets = super.mint(shares, receiver)) < minimumDepositAmount) {
+            revert LessThanMinDeposit(assets, minimumDepositAmount);
+        }
+    }
+
+    /// @notice Withdraws assets from the vault and transfers them to the
+    ///         receiver.
+    /// @dev Withdraw unallocated assets first and and if not enough, then pull
+    ///      the assets from the dispatcher.
+    /// @param assets Amount of assets to withdraw.
+    /// @param receiver The address to which the assets will be transferred.
+    /// @param owner The address of the owner of the shares.
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        uint256 currentAssetsBalance = IERC20(asset()).balanceOf(address(this));
+        // If there is not enough assets in the vault to cover user withdrawals and
+        // withdrawal fees then pull the assets from the dispatcher.
+        uint256 assetsWithFees = assets + _feeOnRaw(assets, exitFeeBasisPoints);
+        if (assetsWithFees > currentAssetsBalance) {
+            dispatcher.withdraw(assetsWithFees - currentAssetsBalance);
+        }
+
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    /// @notice Redeems shares for assets and transfers them to the receiver.
+    /// @dev Redeem unallocated assets first and and if not enough, then pull
+    ///      the assets from the dispatcher.
+    /// @param shares Amount of shares to redeem.
+    /// @param receiver The address to which the assets will be transferred.
+    /// @param owner The address of the owner of the shares.
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        uint256 assets = convertToAssets(shares);
+        uint256 currentAssetsBalance = IERC20(asset()).balanceOf(address(this));
+        if (assets > currentAssetsBalance) {
+            dispatcher.withdraw(assets - currentAssetsBalance);
+        }
+
+        return super.redeem(shares, receiver, owner);
+    }
+
+    /// @notice Returns the total amount of assets held by the vault across all
+    ///         allocations and this contract.
+    function totalAssets() public view override returns (uint256) {
+        return
+            IERC20(asset()).balanceOf(address(this)) + dispatcher.totalAssets();
+    }
+
+    /// @dev Returns the maximum amount of the underlying asset that can be
+    ///      deposited into the Vault for the receiver, through a deposit call.
+    ///      If the Vault is paused, returns 0.
+    function maxDeposit(address) public view override returns (uint256) {
+        if (paused()) {
+            return 0;
+        }
+        return type(uint256).max;
+    }
+
+    /// @dev Returns the maximum amount of the Vault shares that can be minted
+    ///      for the receiver, through a mint call.
+    ///      If the Vault is paused, returns 0.
+    function maxMint(address) public view override returns (uint256) {
+        if (paused()) {
+            return 0;
+        }
+        return type(uint256).max;
+    }
+
+    /// @dev Returns the maximum amount of the underlying asset that can be
+    ///      withdrawn from the owner balance in the Vault, through a withdraw call.
+    ///      If the Vault is paused, returns 0.
+    function maxWithdraw(address owner) public view override returns (uint256) {
+        if (paused()) {
+            return 0;
+        }
+        return super.maxWithdraw(owner);
+    }
+
+    /// @dev Returns the maximum amount of Vault shares that can be redeemed from
+    ///      the owner balance in the Vault, through a redeem call.
+    ///      If the Vault is paused, returns 0.
+    function maxRedeem(address owner) public view override returns (uint256) {
+        if (paused()) {
+            return 0;
+        }
+        return super.maxRedeem(owner);
+    }
+
+    /// @notice Returns the number of assets that corresponds to the amount of
+    ///         shares held by the specified account.
+    /// @dev    This function is used to convert shares to assets position for
+    ///         the given account. It does not take fees into account.
+    /// @param account The owner of the shares.
+    /// @return The amount of assets.
+    function assetsBalanceOf(address account) public view returns (uint256) {
+        return convertToAssets(balanceOf(account));
+    }
+
+    /// @return Returns entry fee basis point used in deposits.
+    function _entryFeeBasisPoints() internal view override returns (uint256) {
+        return entryFeeBasisPoints;
+    }
+
+    /// @return Returns exit fee basis point used in withdrawals.
+    function _exitFeeBasisPoints() internal view override returns (uint256) {
+        return exitFeeBasisPoints;
+    }
+
+    /// @notice Returns the address of the treasury wallet, where fees should be
+    ///         transferred to.
+    function _feeRecipient() internal view override returns (address) {
+        return treasury;
+    }
+}

--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -10,6 +10,9 @@ import "./lib/ERC4626Fees.sol";
 import "./interfaces/IDispatcher.sol";
 import {ZeroAddress} from "./utils/Errors.sol";
 
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {MezoAllocator} from "./MezoAllocator.sol";
+
 /// @title stBTC
 /// @notice This contract implements the ERC-4626 tokenized vault standard. By
 ///         staking tBTC, users acquire a liquid staking token called stBTC,
@@ -56,6 +59,12 @@ contract stBTC is ERC4626Fees, PausableOwnable {
     ///      without the coverage in deposited assets. The value is used to
     ///      adjust the total assets held by the vault.
     uint256 public totalDebt;
+
+    /// @notice Address of ERC-4626 contract to migrate to.
+    address public migrateTo;
+
+    /// @notice Whether the migration has started.
+    bool public migrationStarted;
 
     /// Emitted when the treasury wallet address is updated.
     /// @param oldTreasury Address of the old treasury wallet.
@@ -108,6 +117,10 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         uint256 shares
     );
 
+    /// @notice Emitted when the migration has started.
+    /// @param migrateTo Address of the ERC-4626 contract to migrate to.
+    event MigrationStarted(address migrateTo);
+
     /// Reverts if the amount is less than the minimum deposit amount.
     /// @param amount Amount to check.
     /// @param min Minimum amount to check 'amount' against.
@@ -143,6 +156,12 @@ contract stBTC is ERC4626Fees, PausableOwnable {
     /// @param debt Current debt of the debtor.
     /// @param needed Requested amount of assets repaying the debt.
     error ExcessiveDebtRepayment(address debtor, uint256 debt, uint256 needed);
+
+    /// @notice Reverts if the migration has already started.
+    error MigrationAlreadyStarted();
+
+    /// @notice Reverts if the migration has not started.
+    error MigrationNotStarted();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -482,7 +501,7 @@ contract stBTC is ERC4626Fees, PausableOwnable {
     ///      deposited into the Vault for the receiver, through a deposit call.
     ///      If the Vault is paused, returns 0.
     function maxDeposit(address) public view override returns (uint256) {
-        if (paused()) {
+        if (paused() || migrationStarted) {
             return 0;
         }
         return type(uint256).max;
@@ -492,7 +511,7 @@ contract stBTC is ERC4626Fees, PausableOwnable {
     ///      for the receiver, through a mint call.
     ///      If the Vault is paused, returns 0.
     function maxMint(address) public view override returns (uint256) {
-        if (paused()) {
+        if (paused() || migrationStarted) {
             return 0;
         }
         return type(uint256).max;
@@ -516,6 +535,79 @@ contract stBTC is ERC4626Fees, PausableOwnable {
             return 0;
         }
         return super.maxRedeem(owner);
+    }
+
+    /// @notice Starts the migration to the new contract.
+    /// @dev This function is called by the owner to start the migration.
+    ///      The migration can be started only once.
+    /// @param _migrateTo Address of the ERC-4626 contract to migrate to.
+    function startMigration(address _migrateTo) external onlyOwner {
+        if (address(_migrateTo) == address(0)) {
+            revert ZeroAddress();
+        }
+        if (migrationStarted) {
+            revert MigrationAlreadyStarted();
+        }
+
+        // Set the new contract address.
+        migrateTo = _migrateTo;
+
+        emit MigrationStarted(_migrateTo);
+
+        // Mark the migration as started.
+        migrationStarted = true;
+
+        // Revoke approval for the dispatcher contract so it can't pull assets
+        // from the vault.
+        IERC20(asset()).forceApprove(address(dispatcher), 0);
+
+        // Release the deposit from the MezoAllocator contract.
+        MezoAllocator(address(dispatcher)).releaseDeposit();
+    }
+
+    /// @notice Migrates the deposit of the owner to the new contract.
+    /// @dev This function is called by the owner to migrate the deposit of the
+    ///      depositors without their approval.
+    ///      The deposits that are being migrated have to be covered by the
+    ///      assets deposited to the vault, which excludes the shares that were
+    ///      minted as debt.
+    /// @param owner The address of the owner of the deposit to migrate.
+    function migrateDeposit(address owner) external onlyOwner {
+        if (migrateTo == address(0)) {
+            revert ZeroAddress();
+        }
+        if (paused()) {
+            revert EnforcedPause();
+        }
+        if (!migrationStarted) {
+            revert MigrationNotStarted();
+        }
+
+        uint256 shares = balanceOf(owner);
+        uint256 assets = convertToAssets(shares);
+
+        // We need to ensure the shares were not minted as debt, so they
+        // are covered by the assets deposited to the vault.
+        if (withdrawableShares[owner] < shares) {
+            shares = withdrawableShares[owner];
+        }
+
+        if (shares == 0) {
+            return;
+        }
+
+        // Adjust the withdrawable shares to exclude the shares that are being
+        // migrated and keep the rest of shares associated with debt.
+        withdrawableShares[owner] = 0;
+
+        // Burn the shares that are being migrated.
+        _burn(owner, shares);
+
+        // Approve the assets to be transferred to the new contract.
+        IERC20(asset()).forceApprove(migrateTo, assets);
+
+        // Deposit the assets to the new contract.
+        IERC4626(migrateTo).deposit(assets, owner);
     }
 
     /// @notice Returns the number of assets that corresponds to the amount of


### PR DESCRIPTION
This PR introduces the acreBTC contract and migration of deposits from stBTC to acreBTC.

#### acreBTC

The acreBTC contract is a copy of the stBTC contract with removed features related to
debt.

#### Migration

The stBTC contract is enhanced with a migration feature that allows to migrate
the deposit of an owner to a new ERC-4626 contract.

Once the migration phase is started, the funds are released from the MezoAllocator
and routed to the stBTC contract.

The MezoAllocator contract is unauthorized from accessing the assets of the
stBTC contract.

During the migration, new deposits are not allowed.

The owner of the stBTC contract can migrate the deposits of the depositors
without their approval. The migration is done by burning the shares that are
being migrated and depositing the assets to the new contract.

The migration takes into account the shares that were minted as debt, excluding
them from the assets that are being migrated.

TODO:
- [ ] tests