### PR TITLE
stBTC shares migration improvements and tests

### DIFF
--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -163,6 +163,9 @@ contract stBTC is ERC4626Fees, PausableOwnable {
     /// @notice Reverts if the migration has not started.
     error MigrationNotStarted();
 
+    /// @notice Reverts if the migrateTo address is not set.
+    error MigrateToNotSet();
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -576,7 +579,7 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         address depositOwner
     ) external onlyOwner returns (uint256) {
         if (migrateTo == address(0)) {
-            revert ZeroAddress();
+            revert MigrateToNotSet();
         }
         if (paused()) {
             revert EnforcedPause();

--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -121,6 +121,18 @@ contract stBTC is ERC4626Fees, PausableOwnable {
     /// @param migrateTo Address of the ERC-4626 contract to migrate to.
     event MigrationStarted(address migrateTo);
 
+    /// Emitted when a deposit is migrated.
+    /// @param depositOwner Address of the owner of the deposit.
+    /// @param assets Amount of assets migrated.
+    /// @param oldShares Amount of shares migrated.
+    /// @param newShares Amount of shares migrated to the new vault.
+    event DepositMigrated(
+        address indexed depositOwner,
+        uint256 assets,
+        uint256 oldShares,
+        uint256 newShares
+    );
+
     /// Reverts if the amount is less than the minimum deposit amount.
     /// @param amount Amount to check.
     /// @param min Minimum amount to check 'amount' against.
@@ -610,7 +622,11 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         IERC20(asset()).forceApprove(migrateTo, assets);
 
         // Deposit the assets to the new contract.
-        return IERC4626(migrateTo).deposit(assets, depositOwner);
+        uint256 newShares = IERC4626(migrateTo).deposit(assets, depositOwner);
+
+        emit DepositMigrated(depositOwner, assets, shares, newShares);
+
+        return newShares;
     }
 
     /// @notice Returns the number of assets that corresponds to the amount of

--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -586,7 +586,6 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         }
 
         uint256 shares = balanceOf(depositOwner);
-        uint256 assets = convertToAssets(shares);
 
         // We need to ensure the shares were not minted as debt, so they
         // are covered by the assets deposited to the vault.
@@ -597,6 +596,8 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         if (shares == 0) {
             return 0;
         }
+
+        uint256 assets = convertToAssets(shares);
 
         // Adjust the withdrawable shares to exclude the shares that are being
         // migrated and keep the rest of shares associated with debt.

--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -624,6 +624,7 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         // Deposit the assets to the new contract.
         uint256 newShares = IERC4626(migrateTo).deposit(assets, depositOwner);
 
+        // slither-disable-next-line reentrancy-events
         emit DepositMigrated(depositOwner, assets, shares, newShares);
 
         return newShares;

--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -563,9 +563,6 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         // Revoke approval for the dispatcher contract so it can't pull assets
         // from the vault.
         IERC20(asset()).forceApprove(address(dispatcher), 0);
-
-        // Release the deposit from the MezoAllocator contract.
-        MezoAllocator(address(dispatcher)).releaseDeposit();
     }
 
     /// @notice Migrates a depositor's funds to the new contract.

--- a/solidity/deploy/61_deploy_acrebtc.ts
+++ b/solidity/deploy/61_deploy_acrebtc.ts
@@ -1,0 +1,41 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+import { waitForTransaction } from "../helpers/deployment"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { getNamedAccounts, deployments, helpers } = hre
+  const { treasury, governance } = await getNamedAccounts()
+  const { deployer: deployerSigner } = await helpers.signers.getNamedSigners()
+  const { log } = deployments
+
+  const tbtc = await deployments.get("TBTC")
+
+  let deployment = await deployments.getOrNull("acreBTC")
+  if (deployment && helpers.address.isValid(deployment.address)) {
+    log(`using acreBTC at ${deployment.address}`)
+  } else {
+    ;[, deployment] = await helpers.upgrades.deployProxy("acreBTC", {
+      contractName: "acreBTC",
+      initializerArgs: [tbtc.address, treasury],
+      factoryOpts: {
+        signer: deployerSigner,
+      },
+      proxyOpts: {
+        kind: "transparent",
+        initialOwner: governance,
+      },
+    })
+
+    if (deployment.transactionHash && hre.network.tags.etherscan) {
+      await waitForTransaction(hre, deployment.transactionHash)
+      await helpers.etherscan.verify(deployment)
+    }
+
+    // TODO: Add Tenderly verification
+  }
+}
+
+export default func
+
+func.tags = ["acreBTC"]
+func.dependencies = ["TBTC"]

--- a/solidity/deploy/62_acrebtc_update_dispatcher.ts
+++ b/solidity/deploy/62_acrebtc_update_dispatcher.ts
@@ -1,0 +1,24 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { getNamedAccounts, deployments } = hre
+  const { deployer } = await getNamedAccounts()
+
+  // TODO: Update to the new MidasAllocator
+  const dispatcher = await deployments.get("MezoAllocator")
+
+  await deployments.execute(
+    "acreBTC",
+    { from: deployer, log: true, waitConfirmations: 1 },
+    "updateDispatcher",
+    dispatcher.address,
+  )
+}
+
+export default func
+
+func.tags = ["acreBTCUpdateDispatcher"]
+func.dependencies = ["acreBTC", "MezoAllocator"]
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> =>
+  Promise.resolve(hre.network.name === "integration")

--- a/solidity/test/helpers/context.ts
+++ b/solidity/test/helpers/context.ts
@@ -3,6 +3,7 @@ import { getDeployedContract } from "./contract"
 
 import type {
   StBTC as stBTC,
+  AcreBTC as acreBTC,
   BridgeStub,
   TBTCVaultStub,
   MezoAllocator,
@@ -38,6 +39,8 @@ export async function deployment() {
     await getDeployedContract("MezoAllocator")
   const mezoPortal: MezoPortalStub = await getDeployedContract("MezoPortal")
 
+  const acreBtc: acreBTC = await getDeployedContract("acreBTC")
+
   return {
     tbtc,
     stbtc,
@@ -49,5 +52,6 @@ export async function deployment() {
     tbtcVault,
     mezoAllocator,
     mezoPortal,
+    acreBtc,
   }
 }

--- a/solidity/test/stBTC.test.ts
+++ b/solidity/test/stBTC.test.ts
@@ -12,7 +12,12 @@ import { beforeAfterSnapshotWrapper, deployment } from "./helpers"
 
 import { to1e18 } from "./utils"
 
-import { StBTC as stBTC, TestERC20, MezoAllocator } from "../typechain"
+import {
+  StBTC as stBTC,
+  AcreBTC as acreBTC,
+  TestERC20,
+  MezoAllocator,
+} from "../typechain"
 
 const { getNamedSigners, getUnnamedSigners } = helpers.signers
 

--- a/solidity/test/stBTC.test.ts
+++ b/solidity/test/stBTC.test.ts
@@ -3874,10 +3874,8 @@ describe("stBTC", () => {
         beforeAfterSnapshotWrapper()
 
         let newVault: string
-        let stbtcAddress: string
 
         before(async () => {
-          stbtcAddress = await stbtc.getAddress()
           newVault = await acreBtc.getAddress()
           await stbtc.connect(governance).startMigration(newVault)
         })

--- a/solidity/test/stBTC.test.ts
+++ b/solidity/test/stBTC.test.ts
@@ -17,7 +17,7 @@ import { StBTC as stBTC, TestERC20, MezoAllocator } from "../typechain"
 const { getNamedSigners, getUnnamedSigners } = helpers.signers
 
 async function fixture() {
-  const { tbtc, stbtc, mezoAllocator } = await deployment()
+  const { tbtc, stbtc, mezoAllocator, acreBtc } = await deployment()
   const { governance, treasury, pauseAdmin, maintainer } =
     await getNamedSigners()
 
@@ -40,6 +40,7 @@ async function fixture() {
   return {
     stbtc,
     tbtc,
+    acreBtc,
     depositor1,
     depositor2,
     depositor3,
@@ -64,6 +65,7 @@ describe("stBTC", () => {
   let stbtc: stBTC
   let tbtc: TestERC20
   let mezoAllocator: MezoAllocator
+  let acreBtc: acreBTC
 
   let governance: HardhatEthersSigner
   let depositor1: HardhatEthersSigner
@@ -84,6 +86,7 @@ describe("stBTC", () => {
     ;({
       stbtc,
       tbtc,
+      acreBtc,
       depositor1,
       depositor2,
       depositor3,
@@ -3765,6 +3768,233 @@ describe("stBTC", () => {
         // fee = (2000 * 5) / 10000 = 1
         const expectedFee = 1n
         expect(fee).to.be.eq(expectedFee)
+      })
+    })
+  })
+
+  describe("migrateDeposit", () => {
+    beforeAfterSnapshotWrapper()
+
+    context("when caller is not governance", () => {
+      beforeAfterSnapshotWrapper()
+
+      it("should revert", async () => {
+        await expect(
+          stbtc.connect(thirdParty).migrateDeposit(depositor1.address),
+        )
+          .to.be.revertedWithCustomError(stbtc, "OwnableUnauthorizedAccount")
+          .withArgs(thirdParty.address)
+      })
+    })
+
+    context("when caller is governance", () => {
+      beforeAfterSnapshotWrapper()
+
+      const depositAmount = to1e18(10)
+      const debtAmount = to1e18(5)
+
+      const expectedDepositAssets =
+        depositAmount - feeOnTotal(depositAmount, entryFeeBasisPoints)
+      const expectedDepositShares = expectedDepositAssets
+      const expectedDebtAssets = debtAmount
+      const expectedDebtShares = expectedDebtAssets
+
+      let onlyDebtDepositor: HardhatEthersSigner
+      let onlyDepositDepositor: HardhatEthersSigner
+      let mixedDepositor: HardhatEthersSigner
+
+      before(async () => {
+        onlyDepositDepositor = depositor1
+        onlyDebtDepositor = depositor2
+        mixedDepositor = depositor3
+
+        // Depositor with only debt shares
+        await stbtc
+          .connect(governance)
+          .updateDebtAllowance(onlyDebtDepositor.address, debtAmount)
+
+        await stbtc
+          .connect(onlyDebtDepositor)
+          .mintDebt(to1e18(5), onlyDebtDepositor.address)
+
+        // Depositor with only deposit shares
+        await tbtc.mint(onlyDepositDepositor.address, depositAmount)
+        await tbtc
+          .connect(onlyDepositDepositor)
+          .approve(await stbtc.getAddress(), depositAmount)
+
+        await stbtc
+          .connect(onlyDepositDepositor)
+          .deposit(depositAmount, onlyDepositDepositor.address)
+
+        // Depositor with mixed shares
+        await tbtc.mint(mixedDepositor.address, depositAmount)
+        await tbtc
+          .connect(mixedDepositor)
+          .approve(await stbtc.getAddress(), depositAmount)
+
+        await stbtc
+          .connect(mixedDepositor)
+          .deposit(depositAmount, mixedDepositor.address)
+
+        await stbtc
+          .connect(governance)
+          .updateDebtAllowance(mixedDepositor.address, debtAmount)
+
+        await stbtc
+          .connect(mixedDepositor)
+          .mintDebt(debtAmount, mixedDepositor.address)
+      })
+
+      context("when contract is paused", () => {
+        beforeAfterSnapshotWrapper()
+
+        before(async () => {
+          const newVault = await ethers.Wallet.createRandom().getAddress()
+          await stbtc.connect(governance).startMigration(newVault)
+          await stbtc.connect(pauseAdmin).pause()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            stbtc.connect(governance).migrateDeposit(depositor1.address),
+          ).to.be.revertedWithCustomError(stbtc, "EnforcedPause")
+        })
+      })
+
+      context("when migration has not started", () => {
+        it("should revert", async () => {
+          await expect(
+            stbtc.connect(governance).migrateDeposit(depositor1.address),
+          ).to.be.revertedWithCustomError(stbtc, "MigrateToNotSet")
+        })
+      })
+
+      context("when migration has started", () => {
+        beforeAfterSnapshotWrapper()
+
+        let newVault: string
+        let stbtcAddress: string
+
+        before(async () => {
+          stbtcAddress = await stbtc.getAddress()
+          newVault = await acreBtc.getAddress()
+          await stbtc.connect(governance).startMigration(newVault)
+        })
+
+        context("when depositor has no shares", () => {
+          it("should return 0 and not perform migration", async () => {
+            const result = await stbtc
+              .connect(governance)
+              .migrateDeposit.staticCall(thirdParty.address)
+            expect(result).to.equal(0)
+          })
+        })
+
+        context("when depositor has only debt shares", () => {
+          beforeAfterSnapshotWrapper()
+
+          it("should return 0 as no withdrawable shares exist", async () => {
+            const result = await stbtc
+              .connect(governance)
+              .migrateDeposit.staticCall(onlyDebtDepositor.address)
+            expect(result).to.equal(0)
+          })
+        })
+
+        context("when depositor has regular deposit shares", () => {
+          beforeAfterSnapshotWrapper()
+
+          let tx: ContractTransactionResponse
+
+          before(async () => {
+            tx = await stbtc
+              .connect(governance)
+              .migrateDeposit(onlyDepositDepositor.address)
+          })
+
+          it("should burn all shares from depositor", async () => {
+            await expect(tx).to.changeTokenBalances(
+              stbtc,
+              [onlyDepositDepositor.address],
+              [-expectedDepositShares],
+            )
+          })
+
+          it("should reset withdrawable shares to 0", async () => {
+            expect(
+              await stbtc.withdrawableShares(onlyDepositDepositor.address),
+            ).to.equal(0)
+          })
+
+          it("should return the expected shares amount", async () => {
+            const result = await stbtc
+              .connect(governance)
+              .migrateDeposit.staticCall(onlyDepositDepositor.address)
+            expect(result).to.equal(0) // Returns 0 because shares were already migrated
+          })
+
+          it("should emit a DepositMigrated event", async () => {
+            await expect(tx)
+              .to.emit(stbtc, "DepositMigrated")
+              .withArgs(
+                onlyDepositDepositor.address,
+                expectedDepositAssets,
+                expectedDepositShares,
+                expectedDepositShares,
+              )
+          })
+        })
+
+        context("when depositor has mixed shares (regular + debt)", () => {
+          beforeAfterSnapshotWrapper()
+
+          let tx: ContractTransactionResponse
+
+          before(async () => {
+            tx = await stbtc
+              .connect(governance)
+              .migrateDeposit(mixedDepositor.address)
+          })
+
+          it("should only burn withdrawable shares", async () => {
+            await expect(tx).to.changeTokenBalances(
+              stbtc,
+              [mixedDepositor.address],
+              [-expectedDepositShares],
+            )
+          })
+
+          it("should leave debt shares intact", async () => {
+            const remainingShares = await stbtc.balanceOf(
+              mixedDepositor.address,
+            )
+            expect(remainingShares).to.equal(expectedDebtShares)
+          })
+
+          it("should reset withdrawable shares to 0", async () => {
+            expect(
+              await stbtc.withdrawableShares(mixedDepositor.address),
+            ).to.equal(0)
+          })
+
+          it("should preserve debt amount", async () => {
+            expect(await stbtc.currentDebt(mixedDepositor.address)).to.equal(
+              debtAmount,
+            )
+          })
+
+          it("should emit a DepositMigrated event", async () => {
+            await expect(tx)
+              .to.emit(stbtc, "DepositMigrated")
+              .withArgs(
+                mixedDepositor.address,
+                expectedDepositAssets,
+                expectedDepositShares,
+                expectedDepositShares,
+              )
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
This PR primarily addresses an issue with the `migrateDeposit` function that incorrectly calculates the assets value before the shares value gets updated.

Refs ACR-52