### PR TITLE
Revert "Show "Max" button for BTC deposit amount form (#960)"

### DIFF
--- a/dapp/src/components/TransactionModal/ActiveStakingStep/StakeFormModal/index.tsx
+++ b/dapp/src/components/TransactionModal/ActiveStakingStep/StakeFormModal/index.tsx
@@ -29,7 +29,7 @@ function StakeFormModal({
       tokenBalance={tokenBalance ?? 0n}
       minTokenAmount={minDepositAmount}
       onSubmitForm={onSubmitForm}
-      withMaxButton
+      withMaxButton={false}
     >
       {featureFlags.ACRE_POINTS_ENABLED && (
         <AcrePointsRewardEstimation mt={5} />


### PR DESCRIPTION
This reverts commit 3f13d54ced8a5e0e699e1003c695af745e78c4b4, reversing changes made to cb01c405ee564903aa309f3f4f5cfc508df44a0e.

It shouldn't get merged:
> the Max button was not available on the Deposit form intentionally. When the user hits the Max button, there is no amount left in the wallet to cover the transaction fees.

Ref: https://linear.app/acrefi/issue/ACR-35/add-max-option-to-btc-deposit