### PR TITLE
Reduce withdrawable share instead of setting to 0

### DIFF
--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -618,7 +618,7 @@ contract stBTC is ERC4626Fees, PausableOwnable {
 
         // Adjust the withdrawable shares to exclude the shares that are being
         // migrated and keep the rest of shares associated with debt.
-        withdrawableShares[depositOwner] = 0;
+        withdrawableShares[depositOwner] -= shares;
 
         // Burn the shares that are being migrated.
         _burn(depositOwner, shares);


### PR DESCRIPTION
It may happen that withdrawable shares is greater than the number of shares held by the user, so we adjust the calculation.