### PR TITLE
Deploy v2 subgraphs

### DIFF
--- a/subgraph/config/mainnet.json
+++ b/subgraph/config/mainnet.json
@@ -1,8 +1,8 @@
 {
   "network": "mainnet",
   "bitcoinDepositor": {
-    "address": "0x2Ba614a598Cffa5a19d683cDCA97bac3a49313d1",
-    "startBlock": 20235512
+    "address": "0xe5F48D3d31baf15dfF89fb394F10A5362711c777",
+    "startBlock": 23357093
   },
   "bitcoinRedeemer": {
     "address": "0x7e184B0cC12572D12Db6dA248322A0e3618fc756",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -19,7 +19,7 @@
     "prepare:sepolia": "mustache config/sepolia.json subgraph.template.yaml > subgraph.sepolia.yaml",
     "codegen:sepolia": "npm run codegen subgraph.sepolia.yaml",
     "build:sepolia": "npm run build subgraph.sepolia.yaml",
-    "deploy:sepolia": "graph deploy --studio acre subgraph.sepolia.yaml",
+    "deploy:sepolia": "graph deploy --studio acre-sepolia subgraph.sepolia.yaml",
     "prepare:mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.mainnet.yaml",
     "codegen:mainnet": "npm run codegen subgraph.mainnet.yaml",
     "build:mainnet": "npm run build subgraph.mainnet.yaml",

--- a/subgraph/subgraph.mainnet.yaml
+++ b/subgraph/subgraph.mainnet.yaml
@@ -12,9 +12,9 @@ dataSources:
         type: Bytes
         data: "0x5e4861a80B55f035D899f66772117F00FA0E8e7B"
     source:
-      address: "0x2Ba614a598Cffa5a19d683cDCA97bac3a49313d1"
+      address: "0xe5F48D3d31baf15dfF89fb394F10A5362711c777"
       abi: BitcoinDepositor
-      startBlock: 20235512
+      startBlock: 23357093
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION
Fix `deploy:sepolia` script in package json - we updated the subgraph slug but we forgot to update in `package.json`.

Update supgraph config - set correct contract address and start block for the `BitcoinDepositorV2` contract.

[Mainnet deploy](https://thegraph.com/explorer/subgraphs/DJfS9X5asHtFEdAPikBcSLw8jtKmFcbReQVEa2iY9C9?view=Query&chain=arbitrum-one)
[Testnet deploy](https://thegraph.com/explorer/subgraphs/EWHDjvPcvyeaHyB6a4E8EEad1g73hrec7PeHDatMFiXz?view=Query&chain=arbitrum-one)