### PR TITLE
Fix apr in vaults table and `FeaturedMetricsCard` component 

### DIFF
--- a/dapp/src/components/Vaults.tsx
+++ b/dapp/src/components/Vaults.tsx
@@ -128,7 +128,7 @@ function Vaults(props: VaultsRootProps) {
     {
       provider: "tbtc",
       portfolioWeight: 1,
-      apr: 0.14,
+      apr: 14,
       tvl: statistics.data.tvl.usdValue,
       curator: "re7",
     },
@@ -143,7 +143,7 @@ function Vaults(props: VaultsRootProps) {
             vault.portfolioWeight,
             1,
           )
-          const aprPercentage = getPercentValue(vault.apr, 1)
+          const aprPercentage = getPercentValue(vault.apr, 100)
           const formattedTvlCap = formatNumberToCompactString(
             statistics.data.tvl.cap,
             { currency: "USD", withAutoCompactFormat: true },

--- a/dapp/src/components/shared/FeaturedMetricsCard.tsx
+++ b/dapp/src/components/shared/FeaturedMetricsCard.tsx
@@ -48,12 +48,12 @@ function FeaturedMetricsCard({
 
       <CardBody as={Flex} flexDirection="column" gap={1}>
         <Text size="2xl" fontWeight="semibold">
-          {isLoading ? <Skeleton height="1em" /> : primaryValue}
+          {isLoading ? <Skeleton as="span" height="1em" /> : primaryValue}
         </Text>
 
         {secondaryValue && (
           <Text fontSize="sm" color="neutral.60">
-            {isLoading ? <Skeleton height="1em" /> : secondaryValue}
+            {isLoading ? <Skeleton as="span" height="1em" /> : secondaryValue}
           </Text>
         )}
       </CardBody>


### PR DESCRIPTION
Fix displaying APR in the vaults table and fix `FeaturedMetricsCard` component - do not render `div` inside `p` tag.