### PR TITLE
Fix vault details modal crash on missing BTC price

### DIFF
--- a/dapp/src/components/MidasVaultDetails.tsx
+++ b/dapp/src/components/MidasVaultDetails.tsx
@@ -47,6 +47,17 @@ function AddressValue({ children }: { children: React.ReactNode }) {
   )
 }
 
+// The USD values depend on the BTC price from the Acre API, so they are not
+// available until that request resolves, and stay unavailable if it fails.
+function formatUsdValue(value?: number) {
+  if (value === undefined) return "Loading..."
+
+  return formatNumberToCompactString(value, {
+    currency: "USD",
+    withAutoCompactFormat: true,
+  })
+}
+
 export function getMidasVaultDetails({
   depositFeePercentage,
   withdrawalFeePercentage,
@@ -55,8 +66,8 @@ export function getMidasVaultDetails({
 }: {
   depositFeePercentage?: number
   withdrawalFeePercentage?: number
-  tvlCapInUsd: number
-  vaultTvlInUsd: number
+  tvlCapInUsd?: number
+  vaultTvlInUsd?: number
 }) {
   return {
     vaultName: "Midas acreBTC (macreBTC) Vault",
@@ -105,17 +116,11 @@ export function getMidasVaultDetails({
         items: [
           {
             label: "Active Bitcoin Earning",
-            value: formatNumberToCompactString(vaultTvlInUsd, {
-              currency: "USD",
-              withAutoCompactFormat: true,
-            }),
+            value: formatUsdValue(vaultTvlInUsd),
           },
           {
             label: "TVL Cap",
-            value: formatNumberToCompactString(tvlCapInUsd, {
-              currency: "USD",
-              withAutoCompactFormat: true,
-            }),
+            value: formatUsdValue(tvlCapInUsd),
           },
         ],
       },

--- a/dapp/src/components/VaultDetailsModal.tsx
+++ b/dapp/src/components/VaultDetailsModal.tsx
@@ -42,8 +42,8 @@ export type VaultDetails = {
 type VaultParamDetails = {
   depositFeePercentage?: number
   withdrawalFeePercentage?: number
-  tvlCapInUsd: number
-  vaultTvlInUsd: number
+  tvlCapInUsd?: number
+  vaultTvlInUsd?: number
 }
 
 export type VaultDetailsModalBaseProps = BaseModalProps & {


### PR DESCRIPTION
Opening the vault details modal on production takes the whole page down with `Cannot read properties of undefined (reading 'toLocaleString')`. The Acre API currently returns 500 for `currency/btc`, so the BTC price in the store stays at its initial 0, `useCurrencyConversion` returns `undefined` for the TVL cap, and that `undefined` reached `formatNumberToCompactString`.

The TVL rows now fall back to "Loading..." when the USD value is missing, matching how the fee rows already handle a missing percentage. TypeScript never saw the mismatch because modal props go through `ModalProps = Record<string, unknown>`, so `openModal` does not type-check its payload. Widening that type is worth doing, but it is a bigger change than this fix.

This only stops the crash. The API side still needs fixing, both endpoints the dashboard uses are down:

```
$ curl https://api.acre.fi/api/v1/currency/btc
{"status":500,"error":"Internal Server Error"}
$ curl https://api.acre.fi/api/v1/statistics
{"status":500,"error":"Internal Server Error"}
```

Verified with `eslint` (clean on both files) and `tsc --noEmit` (same 5 pre-existing errors before and after, all in unrelated files).