### PR TITLE
Track tBTC withdrawals in subgrpah

### DIFF
--- a/dapp/src/components/TransactionModal/ActiveUnstakingStep/SignMessageModal.tsx
+++ b/dapp/src/components/TransactionModal/ActiveUnstakingStep/SignMessageModal.tsx
@@ -140,6 +140,7 @@ export default function SignMessageModal() {
             id: activityId,
             txHash: activityTxHash,
             type: "withdraw",
+            destination: destination.type === "tbtc" ? "ethereum" : "bitcoin",
             status: "pending",
             // This is a requested amount. The amount of BTC received will be
             // around: `amount - transactionFee.total`.

--- a/dapp/src/components/TransactionModal/ActiveUnstakingStep/UnstakeFormModal/UnstakeFormBase.tsx
+++ b/dapp/src/components/TransactionModal/ActiveUnstakingStep/UnstakeFormModal/UnstakeFormBase.tsx
@@ -90,11 +90,9 @@ export default function UnstakeFormBase({
         }
         tokenAmountLabel={tokenAmountLabel}
         currency={currency}
-        // TODO: add  isDisabled prop
-        // isDisabled
+        isDisabled
         // The full balance is Formik's initial value - a withdrawal exits the
-        // whole position. Adding `isDisabled` here locks the field to it; left
-        // editable for now so the amount can be varied in testing.
+        // whole position. Adding `isDisabled` here locks the field to it.
         autoComplete="off"
       />
 

--- a/dapp/src/hooks/useActivities.ts
+++ b/dapp/src/hooks/useActivities.ts
@@ -52,7 +52,14 @@ export default function useActivities<TSelected = Activity[]>(
           return {
             id: withdraw.id,
             initializedAt,
-            txHash: withdraw.bitcoinTransactionId,
+            // A tBTC withdrawal never reaches the Bitcoin chain, so the only
+            // transaction there is to link to is the Ethereum one that
+            // requested it.
+            txHash:
+              withdraw.destination === "ethereum"
+                ? withdraw.ethereumTransactionId
+                : withdraw.bitcoinTransactionId,
+            destination: withdraw.destination,
             status,
             amount: withdraw.amount,
             type: "withdraw",

--- a/dapp/src/pages/DashboardPage/TransactionHistory/TransactionTable.tsx
+++ b/dapp/src/pages/DashboardPage/TransactionHistory/TransactionTable.tsx
@@ -50,15 +50,21 @@ export default function TransactionTable() {
               <CardBody as={Flex} flexDirection="column" gap={4}>
                 <Flex flexDirection="column">
                   <Flex justifyContent="space-between">
-                    <Text
-                      size="sm"
-                      color="text.primary"
-                      flex={1}
-                      fontWeight="semibold"
-                      textTransform="capitalize"
-                    >
-                      {activity.type}
-                    </Text>
+                    <HStack spacing={2} flex={1}>
+                      <Text
+                        size="sm"
+                        color="text.primary"
+                        fontWeight="semibold"
+                        textTransform="capitalize"
+                      >
+                        {activity.type}
+                      </Text>
+                      {activitiesUtils.isWithdrawToEthereum(activity) && (
+                        <Tag variant="solid" size="sm">
+                          <TagLabel>tBTC on Ethereum</TagLabel>
+                        </Tag>
+                      )}
+                    </HStack>
                     <CurrencyBalance
                       color="text.primary"
                       size="sm"
@@ -78,7 +84,11 @@ export default function TransactionTable() {
                     {activity.txHash ? (
                       <BlockExplorerLink
                         id={activity.txHash}
-                        chain="bitcoin"
+                        chain={
+                          activitiesUtils.isWithdrawToEthereum(activity)
+                            ? "ethereum"
+                            : "bitcoin"
+                        }
                         type="transaction"
                         color="text.primary"
                         _groupHover={{

--- a/dapp/src/types/activity.ts
+++ b/dapp/src/types/activity.ts
@@ -13,7 +13,11 @@ type ConditionalActivityData =
     }
   | {
       type: "withdraw"
+      // The chain the `txHash` belongs to depends on the destination: a Bitcoin
+      // withdrawal links to the redemption transaction on Bitcoin, a tBTC one
+      // to the Ethereum transaction that requested it.
       txHash?: string
+      destination: "bitcoin" | "ethereum"
     }
 
 export type ActivityType = ConditionalActivityData["type"]

--- a/dapp/src/utils/activitiesUtils.ts
+++ b/dapp/src/utils/activitiesUtils.ts
@@ -25,6 +25,11 @@ const sortActivitiesByTimestamp = (activities: Activity[]): Activity[] =>
 
 const isWithdrawType = (type: ActivityType) => type === "withdraw"
 
+// A withdrawal paid out in tBTC to an Ethereum address, rather than bridged to
+// Bitcoin. Its transaction hash is an Ethereum one.
+const isWithdrawToEthereum = (activity: Activity): boolean =>
+  activity.type === "withdraw" && activity.destination === "ethereum"
+
 function getEstimatedDuration(
   amount: bigint,
   type: ActivityType,
@@ -70,5 +75,6 @@ export default {
   hasPendingDeposits,
   sortActivitiesByTimestamp,
   isWithdrawType,
+  isWithdrawToEthereum,
   getEstimatedDuration,
 }

--- a/dapp/test/utils/activitiesUtils.test.ts
+++ b/dapp/test/utils/activitiesUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { activitiesUtils } from "#/utils"
+import { Activity } from "#/types"
 
 describe("Utils functions for activities", () => {
   describe("getEstimatedDuration", () => {
@@ -54,5 +55,49 @@ describe("Utils functions for activities", () => {
         })
       })
     })
+  })
+
+  describe("isWithdrawToEthereum", () => {
+    const baseActivity = {
+      id: "1",
+      initializedAt: 1760240000,
+      amount: 1000n,
+      status: "requested",
+    } as const
+
+    describe.each([
+      {
+        name: "a withdrawal paid out in tBTC",
+        activity: {
+          ...baseActivity,
+          type: "withdraw",
+          destination: "ethereum",
+        },
+        expectedResult: true,
+      },
+      {
+        name: "a withdrawal bridged to Bitcoin",
+        activity: {
+          ...baseActivity,
+          type: "withdraw",
+          destination: "bitcoin",
+        },
+        expectedResult: false,
+      },
+      {
+        name: "a deposit",
+        activity: { ...baseActivity, type: "deposit" },
+        expectedResult: false,
+      },
+    ] as { name: string; activity: Activity; expectedResult: boolean }[])(
+      "when it is $name",
+      ({ activity, expectedResult }) => {
+        it(`should return ${expectedResult}`, () => {
+          expect(activitiesUtils.isWithdrawToEthereum(activity)).toBe(
+            expectedResult,
+          )
+        })
+      },
+    )
   })
 })

--- a/sdk/src/acre.ts
+++ b/sdk/src/acre.ts
@@ -99,7 +99,7 @@ class Acre {
       network === BitcoinNetwork.Mainnet
         ? // TODO: Figure out why this link doesn't point to the latest published version
           // ? `https://gateway-arbitrum.network.thegraph.com/api/${subgraphApiKey}/subgraphs/id/DJfS9X5asHtFEdAPikBcSLw8jtKmFcbReQVEa2iY9C9`
-          `https://gateway-arbitrum.network.thegraph.com/api/${subgraphApiKey}/deployments/id/QmXM9RdRjBnVpZsX7w3MS8M1BxeazVBPmM4cfUQhgpLjwP`
+          `https://gateway-arbitrum.network.thegraph.com/api/${subgraphApiKey}/deployments/id/Qmezx4QssS3MUgy4bmBf2rN2Ps793dBKQjubDcYBQNj3MJ`
         : "https://api.studio.thegraph.com/query/73600/acre-sepolia/version/latest"
 
     const subgraph = new AcreSubgraphApi(acreSubgraphApiUrl)

--- a/sdk/src/lib/api/AcreSubgraphApi.ts
+++ b/sdk/src/lib/api/AcreSubgraphApi.ts
@@ -76,6 +76,14 @@ type Deposit = {
   finalizedAt?: number
 }
 
+/**
+ * Where the redeemed assets are delivered. `Bitcoin` goes through the tBTC
+ * Bridge, `Ethereum` pays tBTC out to an Ethereum address.
+ */
+export type WithdrawalDestination = "bitcoin" | "ethereum"
+
+type WithdrawalEventType = "Requested" | "Initialized" | "Finalized"
+
 type WithdrawalsDataResponse = {
   data: {
     withdraws: {
@@ -84,8 +92,10 @@ type WithdrawalsDataResponse = {
       amount: string
       requestedAmount: string
       amountToRedeem: string
+      destination: "Bitcoin" | "Ethereum"
       events: {
-        type: "Requested" | "Initialized" | "Finalized"
+        id: string
+        type: WithdrawalEventType
         timestamp: string
       }[]
     }[]
@@ -116,6 +126,14 @@ type Withdrawal = {
    */
   bitcoinTransactionId?: string
   /**
+   * Where the withdrawal is delivered.
+   */
+  destination: WithdrawalDestination
+  /**
+   * Hash of the Ethereum transaction that requested the withdrawal.
+   */
+  ethereumTransactionId: string
+  /**
    * Timestamp when the withdrawal was requested.
    */
   requestedAt: number
@@ -127,6 +145,20 @@ type Withdrawal = {
    * Timestamp when the withdrawal was finalized.
    */
   finalizedAt?: number
+}
+
+/**
+ * Extracts the Ethereum transaction hash from a subgraph event id. The subgraph
+ * builds every event id as `<transactionHash>_<name>`, or
+ * `<transactionHash>_<activityId>_<name>` where one transaction emits the same
+ * event for several activities - the transaction hash is always the first
+ * segment. See `Event` in `subgraph/schema.graphql`.
+ *
+ * @param eventId The event id returned by the subgraph.
+ * @returns The Ethereum transaction hash.
+ */
+function getTransactionHashFromEventId(eventId: string): string {
+  return eventId.split("_")[0]
 }
 
 export function buildGetDepositsByOwnerQuery(owner: ChainIdentifier) {
@@ -158,7 +190,9 @@ export function buildGetWithdrawalsByOwnerQuery(owner: ChainIdentifier) {
         requestedAmount
         amountToRedeem
         amount
+        destination
         events(orderBy: timestamp, orderDirection: asc) {
+          id
           timestamp
           type
         }
@@ -261,23 +295,34 @@ export default class AcreSubgraphApi extends HttpApi {
         ? BigInt(withdraw.amount)
         : BigInt(withdraw.amountToRedeem)
 
-      const [requestedEvent, initializedEvent, finalizedEvent] = events
-      const requestedAt = parseInt(requestedEvent.timestamp, 10)
-      const initializedAt = initializedEvent
-        ? parseInt(initializedEvent.timestamp, 10)
-        : undefined
-      const finalizedAt = finalizedEvent
-        ? parseInt(finalizedEvent.timestamp, 10)
-        : undefined
+      // Look the events up by type rather than by position: a withdrawal paid
+      // out in tBTC never goes through the tBTC Bridge, so it has no
+      // `Initialized` stage, and positionally its `Finalized` event would be
+      // read as the initialization.
+      const findEventTimestamp = (type: WithdrawalEventType) => {
+        const event = events.find((e) => e.type === type)
+        return event ? parseInt(event.timestamp, 10) : undefined
+      }
+
+      const requestedEvent = events.find(({ type }) => type === "Requested")
 
       return {
         id,
         bitcoinTransactionId,
         amount,
         requestedAmount,
-        requestedAt,
-        initializedAt,
-        finalizedAt,
+        destination:
+          withdraw.destination === "Ethereum"
+            ? ("ethereum" as const)
+            : ("bitcoin" as const),
+        ethereumTransactionId: requestedEvent
+          ? getTransactionHashFromEventId(requestedEvent.id)
+          : "",
+        requestedAt: requestedEvent
+          ? parseInt(requestedEvent.timestamp, 10)
+          : 0,
+        initializedAt: findEventTimestamp("Initialized"),
+        finalizedAt: findEventTimestamp("Finalized"),
       }
     })
   }

--- a/sdk/src/modules/account.ts
+++ b/sdk/src/modules/account.ts
@@ -52,7 +52,12 @@ type WithdrawalStatus = "requested" | "initialized" | "finalized"
 export type Withdrawal = {
   id: string
   requestedAmount: bigint
-  amount?: bigint
+  /**
+   * Always present: the subgraph reports it once the withdrawal completes, and
+   * until then `AcreSubgraphApi` falls back to the amount the withdrawal was
+   * requested for.
+   */
+  amount: bigint
   bitcoinTransactionId?: string
   /**
    * Where the withdrawal is delivered - bridged to Bitcoin, or paid out in tBTC

--- a/sdk/src/modules/account.ts
+++ b/sdk/src/modules/account.ts
@@ -3,7 +3,9 @@ import { AcreContracts, ChainIdentifier } from "../lib/contracts"
 import StakeInitialization from "./staking"
 import { fromSatoshi, toSatoshi, Hex } from "../lib/utils"
 import Tbtc from "./tbtc"
-import AcreSubgraphApi from "../lib/api/AcreSubgraphApi"
+import AcreSubgraphApi, {
+  WithdrawalDestination,
+} from "../lib/api/AcreSubgraphApi"
 import { DepositStatus } from "../lib/api/TbtcApi"
 import { AcreBitcoinProvider } from "../lib/bitcoin"
 
@@ -52,6 +54,15 @@ export type Withdrawal = {
   requestedAmount: bigint
   amount?: bigint
   bitcoinTransactionId?: string
+  /**
+   * Where the withdrawal is delivered - bridged to Bitcoin, or paid out in tBTC
+   * to an Ethereum address.
+   */
+  destination: WithdrawalDestination
+  /**
+   * Hash of the Ethereum transaction that requested the withdrawal.
+   */
+  ethereumTransactionId: string
   status: WithdrawalStatus
   requestedAt: number
   initializedAt?: number

--- a/sdk/test/data/withdrawals.ts
+++ b/sdk/test/data/withdrawals.ts
@@ -8,6 +8,7 @@ export const acreSubgraphWithdrawalsDataResponse = {
         bitcoinTransactionId: null,
         amount: null,
         amountToRedeem: "14947630922693266",
+        destination: "Bitcoin",
         events: [
           {
             id: "0x1d2980a5e55c9201445da5580aa65c304ea046728ee0def257d30469795bde1f_RedeemAndBridgeRequested",
@@ -25,6 +26,7 @@ export const acreSubgraphWithdrawalsDataResponse = {
           "8669000602eee2373124768bebd8751128e861f16fd6f4021eccaf11cba35103",
         amount: "9975062344139650",
         amountToRedeem: "9975062344139650",
+        destination: "Bitcoin",
         events: [
           {
             id: "0x943afdf27e2679685e68b6c664c370c558ebdb0842621cb6fb1a997fc67f1ceb_RedeemAndBridgeRequested",
@@ -43,6 +45,72 @@ export const acreSubgraphWithdrawalsDataResponse = {
           },
         ],
       },
+      // A withdrawal to tBTC through the withdrawal queue, still waiting for
+      // the Midas vault to settle. There is no `Initialized` stage on this
+      // path.
+      {
+        id: "102",
+        redeemerOutputScript: null,
+        requestedAmount: "14833959404665139",
+        bitcoinTransactionId: null,
+        amount: null,
+        amountToRedeem: "14833959404665139",
+        destination: "Ethereum",
+        events: [
+          {
+            id: "0x3c98c97d4194e04f2f043672e6085d864a84d497401354994af7559bf31880d4_RedemptionRequested",
+            timestamp: "1760240000",
+            type: "Requested",
+          },
+        ],
+      },
+      // The same withdrawal once the Midas vault has settled it. The
+      // `Finalized` event belongs to Midas' batched settlement transaction, not
+      // to the user's.
+      {
+        id: "103",
+        redeemerOutputScript: null,
+        requestedAmount: "2469057825000000",
+        bitcoinTransactionId: null,
+        amount: "2469057825000000",
+        amountToRedeem: "2469057825000000",
+        destination: "Ethereum",
+        events: [
+          {
+            id: "0x80c242509dab18a5bbf9335d05b54c93add405b92d570e46023e749b430c8c48_RedemptionRequested",
+            timestamp: "1760250000",
+            type: "Requested",
+          },
+          {
+            id: "0xb383989d30c935ae3d01be27e6be33b48a35ac794e7931cf06c9f28b38f7266c_103_MidasRedeemApproved",
+            timestamp: "1760380000",
+            type: "Finalized",
+          },
+        ],
+      },
+      // A synchronous redemption straight from acreBTC - requested and
+      // finalized in one transaction.
+      {
+        id: "0xe44f54c54d8cef0dd26612a097cdb848a5b1fdb96f81d1a8a7546e4489d1ca50_7",
+        redeemerOutputScript: null,
+        requestedAmount: "99999999999999",
+        bitcoinTransactionId: null,
+        amount: "99999999999999",
+        amountToRedeem: "99999999999999",
+        destination: "Ethereum",
+        events: [
+          {
+            id: "0xe44f54c54d8cef0dd26612a097cdb848a5b1fdb96f81d1a8a7546e4489d1ca50_7_WithdrawRequested",
+            timestamp: "1760400000",
+            type: "Requested",
+          },
+          {
+            id: "0xe44f54c54d8cef0dd26612a097cdb848a5b1fdb96f81d1a8a7546e4489d1ca50_7_WithdrawFinalized",
+            timestamp: "1760400000",
+            type: "Finalized",
+          },
+        ],
+      },
     ],
   },
 }
@@ -53,6 +121,9 @@ export const acreSubgraphApiParsedWithdrawalsData = [
     bitcoinTransactionId: undefined,
     amount: 14947630922693266n,
     requestedAmount: 14985000000000000n,
+    destination: "bitcoin" as const,
+    ethereumTransactionId:
+      "0x1d2980a5e55c9201445da5580aa65c304ea046728ee0def257d30469795bde1f",
     requestedAt: 1759706723,
     initializedAt: undefined,
     finalizedAt: undefined,
@@ -63,8 +134,47 @@ export const acreSubgraphApiParsedWithdrawalsData = [
       "8669000602eee2373124768bebd8751128e861f16fd6f4021eccaf11cba35103",
     requestedAmount: 10000000000000000n,
     amount: 9975062344139650n,
+    destination: "bitcoin" as const,
+    ethereumTransactionId:
+      "0x943afdf27e2679685e68b6c664c370c558ebdb0842621cb6fb1a997fc67f1ceb",
     requestedAt: 1760089859,
     initializedAt: 1760120447,
     finalizedAt: 1760151839,
+  },
+  {
+    id: "102",
+    bitcoinTransactionId: undefined,
+    requestedAmount: 14833959404665139n,
+    amount: 14833959404665139n,
+    destination: "ethereum" as const,
+    ethereumTransactionId:
+      "0x3c98c97d4194e04f2f043672e6085d864a84d497401354994af7559bf31880d4",
+    requestedAt: 1760240000,
+    initializedAt: undefined,
+    finalizedAt: undefined,
+  },
+  {
+    id: "103",
+    bitcoinTransactionId: undefined,
+    requestedAmount: 2469057825000000n,
+    amount: 2469057825000000n,
+    destination: "ethereum" as const,
+    ethereumTransactionId:
+      "0x80c242509dab18a5bbf9335d05b54c93add405b92d570e46023e749b430c8c48",
+    requestedAt: 1760250000,
+    initializedAt: undefined,
+    finalizedAt: 1760380000,
+  },
+  {
+    id: "0xe44f54c54d8cef0dd26612a097cdb848a5b1fdb96f81d1a8a7546e4489d1ca50_7",
+    bitcoinTransactionId: undefined,
+    requestedAmount: 99999999999999n,
+    amount: 99999999999999n,
+    destination: "ethereum" as const,
+    ethereumTransactionId:
+      "0xe44f54c54d8cef0dd26612a097cdb848a5b1fdb96f81d1a8a7546e4489d1ca50",
+    requestedAt: 1760400000,
+    initializedAt: undefined,
+    finalizedAt: 1760400000,
   },
 ]

--- a/sdk/test/modules/account.test.ts
+++ b/sdk/test/modules/account.test.ts
@@ -613,24 +613,25 @@ describe("Account", () => {
       .spyOn(acreSubgraph, "getWithdrawalsByOwner")
       .mockImplementationOnce(() => Promise.resolve(withdrawals))
 
-    const expectedWithdrawals = [
-      {
-        ...withdrawals[0],
-        amount: satoshiConverter.toSatoshi(withdrawals[0].amount),
-        requestedAmount: satoshiConverter.toSatoshi(
-          withdrawals[0].requestedAmount,
-        ),
-        status: "requested",
-      },
-      {
-        ...withdrawals[1],
-        amount: satoshiConverter.toSatoshi(withdrawals[1].amount),
-        requestedAmount: satoshiConverter.toSatoshi(
-          withdrawals[1].requestedAmount,
-        ),
-        status: "finalized",
-      },
+    // The fixtures cover, in order: a Bitcoin withdrawal still being bridged, a
+    // completed Bitcoin withdrawal, a tBTC withdrawal waiting for the Midas
+    // vault to settle, one the vault has settled, and a synchronous redemption
+    // straight from acreBTC. The last three have no `Initialized` stage, so
+    // they exercise the status derivation for the tBTC paths.
+    const expectedStatuses = [
+      "requested",
+      "finalized",
+      "requested",
+      "finalized",
+      "finalized",
     ]
+
+    const expectedWithdrawals = withdrawals.map((withdrawal, index) => ({
+      ...withdrawal,
+      amount: satoshiConverter.toSatoshi(withdrawal.amount),
+      requestedAmount: satoshiConverter.toSatoshi(withdrawal.requestedAmount),
+      status: expectedStatuses[index],
+    }))
 
     let result: Awaited<ReturnType<Account["getWithdrawals"]>>
 

--- a/subgraph/abis/BitcoinRedeemerV3.json
+++ b/subgraph/abis/BitcoinRedeemerV3.json
@@ -1,0 +1,27 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tbtcAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RedemptionRequested",
+    "type": "event"
+  }
+]

--- a/subgraph/abis/MidasRedemptionVault.json
+++ b/subgraph/abis/MidasRedemptionVault.json
@@ -1,0 +1,40 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "requestId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newOutRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeApproveRequest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "requestId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newOutRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "ApproveRequest",
+    "type": "event"
+  }
+]

--- a/subgraph/config/mainnet.json
+++ b/subgraph/config/mainnet.json
@@ -4,22 +4,27 @@
     "address": "0xe5F48D3d31baf15dfF89fb394F10A5362711c777",
     "startBlock": 23357093
   },
-  "bitcoinRedeemer": {
-    "address": "0x42A5f91586DDf041A6084494B0b375CdA34d55e9",
-    "startBlock": 23392604
-  },
   "withdrawalQueue": {
     "address": "0xe7b8c14cA8Fb4f226C0A3e45e636b84809BB5D06",
     "startBlock": 23392669
   },
   "tbtcBridge": {
-    "address": "0x5e4861a80B55f035D899f66772117F00FA0E8e7B"
+    "address": "0x5e4861a80B55f035D899f66772117F00FA0E8e7B",
+    "startBlock": 23392604
   },
   "stbtc": {
     "address": "0xdF217EFD8f3ecb5E837aedF203C28c1f06854017"
   },
   "acrebtc": {
     "address": "0x19531C886339dd28b9923d903F6B235C45396ded",
+    "startBlock": 23349292
+  },
+  "midasRedemptionVault": {
+    "address": "0x319a05E260acC2490768A726Ccfd341D4b3D5106",
+    "startBlock": 23392669
+  },
+  "bitcoinRedeemerV3": {
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 23349292
   }
 }

--- a/subgraph/config/mainnet.json
+++ b/subgraph/config/mainnet.json
@@ -24,7 +24,7 @@
     "startBlock": 23392669
   },
   "bitcoinRedeemerV3": {
-    "address": "0x0000000000000000000000000000000000000000",
-    "startBlock": 23349292
+    "address": "0x1Cf54d1dEfe08Ea34A203708d1Fc19c354b9960B",
+    "startBlock": 25940239
   }
 }

--- a/subgraph/config/sepolia.json
+++ b/subgraph/config/sepolia.json
@@ -24,7 +24,7 @@
     "startBlock": 9169609
   },
   "bitcoinRedeemerV3": {
-    "address": "0x0000000000000000000000000000000000000000",
-    "startBlock": 9190342
+    "address": "0xDCBE41F6dcE0Aca6B7c0e9b68D2D7dD51d9eA8A4",
+    "startBlock": 11667996
   }
 }

--- a/subgraph/config/sepolia.json
+++ b/subgraph/config/sepolia.json
@@ -4,22 +4,27 @@
     "address": "0x4030348c63e1c8EdDc4485d05Ed6FCE5eB2d35b2",
     "startBlock": 9169564
   },
-  "bitcoinRedeemer": {
-    "address": "0xE1d25025835A89C93d56a029C80699BE056584d2",
-    "startBlock": 9169626
-  },
   "withdrawalQueue": {
     "address": "0x02BfDaee4FB33a69Ecbf008Ad5822971A5382884",
     "startBlock": 9169609
   },
   "tbtcBridge": {
-    "address": "0x9b1a7fE5a16A15F2f9475C5B231750598b113403"
+    "address": "0x9b1a7fE5a16A15F2f9475C5B231750598b113403",
+    "startBlock": 9169626
   },
   "stbtc": {
     "address": "0x7e184179b1F95A9ca398E6a16127f06b81Cb37a3"
   },
   "acrebtc": {
     "address": "0xB8ba4B007321e0EB4586De49E59593E0eD66d367",
+    "startBlock": 9190342
+  },
+  "midasRedemptionVault": {
+    "address": "0x6B35F2E4C9D4c1da0eDaf7fd7Dc90D9bCa4b0873",
+    "startBlock": 9169609
+  },
+  "bitcoinRedeemerV3": {
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 9190342
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -5,6 +5,13 @@ enum EventType {
   Migrated
 }
 
+# Where the redeemed assets are delivered. `Bitcoin` goes through the tBTC
+# Bridge, `Ethereum` pays tBTC out to an Ethereum address.
+enum WithdrawalDestination {
+  Bitcoin
+  Ethereum
+}
+
 interface ActivityData @key(fields: "id") {
   id: ID!
   depositOwner: DepositOwner!
@@ -39,10 +46,19 @@ type Withdraw implements ActivityData @entity {
   amountToRedeem: BigInt
   bitcoinTransactionId: String
   redeemerOutputScript: String
+  destination: WithdrawalDestination!
 }
 
 type Event @entity {
-  # Id is the transaction hash.
+  # Id is `<transactionHash>_<name>`, or `<transactionHash>_<activityId>_<name>`
+  # where one transaction settles several activities at once and the name alone
+  # would collide. That happens in two places, both because the counterparty
+  # batches: the Midas Vault approves several redemption requests in one
+  # transaction, and the tBTC Bridge proves one Bitcoin transaction whose
+  # outputs pay several redeemers.
+  #
+  # The transaction hash is always the first segment either way, and the SDK
+  # relies on that to link an activity to Etherscan.
   id: ID!
   timestamp: BigInt!
   activity: ActivityData
@@ -65,6 +81,18 @@ type RedemptionKeyToPendingWithdrawal @entity {
   # keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)
   id: ID!
   withdrawId: String
+}
+
+# Maps a Midas Vault redemption request ID to the withdrawal that filed it. The
+# Midas Vault settles asynchronously and the only thing its settlement event
+# carries is its own request ID, so we have to remember the association at
+# request time. Written only for `WithdrawalQueue.RedeemRequested` - the Bitcoin
+# path also files a Midas request, but it completes when the tBTC Bridge
+# delivers the BTC, not when Midas settles.
+type MidasRequestToWithdrawal @entity {
+  # Midas Vault redemption request ID.
+  id: ID!
+  withdrawId: String!
 }
 
 type RedemptionsCompletedEvent @entity {

--- a/subgraph/src/acrebtc.ts
+++ b/subgraph/src/acrebtc.ts
@@ -1,12 +1,16 @@
 import { Address, dataSource } from "@graphprotocol/graph-ts"
-import { Deposit as DepositEvent } from "../generated/AcreBTC/AcreBTC"
+import {
+  Deposit as DepositEvent,
+  RedemptionRequested as RedemptionRequestedEvent,
+  Withdraw as WithdrawEvent,
+} from "../generated/AcreBTC/AcreBTC"
 import {
   getOrCreateDepositOwner,
   getOrCreateDeposit,
   getOrCreateEvent,
+  getOrCreateWithdraw,
 } from "./utils"
 
-// eslint-disable-next-line import/prefer-default-export
 export function handleDeposit(event: DepositEvent): void {
   const stbtcContractAddress = Address.fromBytes(
     dataSource.context().getBytes("stbtcContractAddress"),
@@ -37,4 +41,97 @@ export function handleDeposit(event: DepositEvent): void {
   depositOwnerEntity.save()
   depositEntity.save()
   eventEntity.save()
+}
+
+// Emitted by `acreBTC.requestRedeem`, which redeems shares for tBTC paid out to
+// an Ethereum address through the Midas `WithdrawalQueue`. The queue's own
+// `RedeemRequested` event carries the amounts but not the owner, so the two
+// halves of the withdrawal are assembled from both - see
+// `handleRedeemRequested`. The queue emits first, this event second, but both
+// handlers create-or-update so the order does not matter.
+//
+// This is the only event of the pair that knows the owner, so it is the one
+// that records the request. The Bitcoin path does the same from the queue
+// side, where `RedeemAndBridgeRequested` does carry the owner.
+export function handleRedemptionRequested(
+  event: RedemptionRequestedEvent,
+): void {
+  const depositOwnerEntity = getOrCreateDepositOwner(event.params.owner)
+  const withdrawEntity = getOrCreateWithdraw(event.params.requestId.toString())
+
+  withdrawEntity.depositOwner = depositOwnerEntity.id
+  withdrawEntity.destination = "Ethereum"
+
+  // Namespaced by request id: one transaction can carry more than one
+  // `requestRedeem` call, and `${tx}_RedemptionRequested` alone is also the id
+  // `tbtc-bridge.ts` builds for the tBTC Bridge event of the same name.
+  const eventEntity = getOrCreateEvent(
+    `${event.transaction.hash.toHexString()}_${event.params.requestId.toString()}_RedemptionRequested`,
+  )
+
+  eventEntity.activity = withdrawEntity.id
+  eventEntity.timestamp = event.block.timestamp
+  eventEntity.type = "Requested"
+
+  depositOwnerEntity.save()
+  withdrawEntity.save()
+  eventEntity.save()
+}
+
+// The ERC4626 `Withdraw` event, emitted by `acreBTC.redeem` or
+// `acreBTC.withdraw`. This is the exit path once
+// `MidasAllocator.emergencyWithdraw()` has moved the tBTC back onto acreBTC and
+// the withdrawal queue is no longer set: the tBTC is paid straight to the
+// receiver in a single transaction, so the withdrawal is requested and
+// finalized at once.
+export function handleWithdraw(event: WithdrawEvent): void {
+  // `BitcoinRedeemerV3` redeems the shares to itself and then asks the tBTC
+  // Bridge to bridge the tBTC to Bitcoin, so this same event also covers
+  // redemptions that never reach an Ethereum address. Those are indexed from
+  // the redeemer's own `RedemptionRequested` event instead - recording them
+  // here would label a Bitcoin withdrawal as a tBTC one, finalize it at
+  // request time while the BTC is still in the Bridge, and duplicate the
+  // entity the redeemer's handler creates.
+  const bitcoinRedeemerV3ContractAddress = Address.fromBytes(
+    dataSource.context().getBytes("bitcoinRedeemerV3ContractAddress"),
+  )
+
+  if (event.params.receiver.equals(bitcoinRedeemerV3ContractAddress)) {
+    return
+  }
+
+  const depositOwnerEntity = getOrCreateDepositOwner(event.params.owner)
+
+  // There is no request ID on this path - the redemption is not queued - so the
+  // withdrawal is keyed by the log that created it.
+  const withdrawId = `${event.transaction.hash.toHexString()}_${event.logIndex.toString()}`
+  const withdrawEntity = getOrCreateWithdraw(withdrawId)
+
+  withdrawEntity.depositOwner = depositOwnerEntity.id
+  withdrawEntity.destination = "Ethereum"
+  // `assets` is what the receiver is actually paid, net of the exit fee. The
+  // fee goes to the treasury in a separate transfer and is not part of this
+  // event, so the requested and redeemed amounts are the same figure here.
+  withdrawEntity.requestedAmount = event.params.assets
+  withdrawEntity.amountToRedeem = event.params.assets
+  withdrawEntity.amount = event.params.assets
+
+  const requestedEventEntity = getOrCreateEvent(
+    `${withdrawId}_WithdrawRequested`,
+  )
+  requestedEventEntity.activity = withdrawEntity.id
+  requestedEventEntity.timestamp = event.block.timestamp
+  requestedEventEntity.type = "Requested"
+
+  const finalizedEventEntity = getOrCreateEvent(
+    `${withdrawId}_WithdrawFinalized`,
+  )
+  finalizedEventEntity.activity = withdrawEntity.id
+  finalizedEventEntity.timestamp = event.block.timestamp
+  finalizedEventEntity.type = "Finalized"
+
+  depositOwnerEntity.save()
+  withdrawEntity.save()
+  requestedEventEntity.save()
+  finalizedEventEntity.save()
 }

--- a/subgraph/src/bitcoin-redeemer-v3-utils.ts
+++ b/subgraph/src/bitcoin-redeemer-v3-utils.ts
@@ -1,0 +1,57 @@
+import {
+  Address,
+  BigInt,
+  ByteArray,
+  Bytes,
+  crypto,
+  dataSource,
+  ethereum,
+} from "@graphprotocol/graph-ts"
+import { getLogByEventSignatureInLogs } from "./utils"
+
+// Careful: `BitcoinRedeemerV2` declares an event of the same name and the same
+// canonical signature - `RedemptionRequested(address,uint256,uint256)` - so the
+// two share this topic, even though V2 indexes its second parameter and V3 does
+// not. Decoding a V2 log with the accessors below would read the wrong values,
+// which is why every lookup here filters on the V3 address as well as the topic.
+const REDEMPTION_REQUESTED = crypto.keccak256(
+  ByteArray.fromUTF8("RedemptionRequested(address,uint256,uint256)"),
+)
+
+export function buildBitcoinRedeemerV3WithdrawId(
+  transactionHash: Bytes,
+  logIndex: BigInt,
+): string {
+  return `${transactionHash.toHexString()}_${logIndex.toString()}`
+}
+
+export function getBitcoinRedeemerV3RedemptionRequestedLog(
+  logs: ethereum.Log[],
+): ethereum.Log | null {
+  const bitcoinRedeemerV3ContractAddress = Address.fromBytes(
+    dataSource.context().getBytes("bitcoinRedeemerV3ContractAddress"),
+  )
+
+  // Returns the last matching log in the receipt. A transaction only ever
+  // carries one redemption - no Acre or tBTC Bridge transaction on mainnet has
+  // ever contained two - so there is nothing to disambiguate.
+  return getLogByEventSignatureInLogs(
+    logs,
+    REDEMPTION_REQUESTED,
+    bitcoinRedeemerV3ContractAddress,
+  )
+}
+
+export function getOwnerFromBitcoinRedeemerV3Log(log: ethereum.Log): Address {
+  // The owner is the only indexed param.
+  return ethereum.decode("address", log.topics[1])!.toAddress()
+}
+
+export function getTbtcAmountFromBitcoinRedeemerV3Log(
+  log: ethereum.Log,
+): BigInt {
+  // `shares` then `tbtcAmount`, both unindexed.
+  const decoded = ethereum.decode("(uint256,uint256)", log.data)!.toTuple()
+
+  return decoded[1].toBigInt()
+}

--- a/subgraph/src/bitcoin-redeemer-v3.ts
+++ b/subgraph/src/bitcoin-redeemer-v3.ts
@@ -1,0 +1,48 @@
+import { RedemptionRequested } from "../generated/BitcoinRedeemerV3/BitcoinRedeemerV3"
+import {
+  getOrCreateDepositOwner,
+  getOrCreateEvent,
+  getOrCreateWithdraw,
+} from "./utils"
+import { buildBitcoinRedeemerV3WithdrawId } from "./bitcoin-redeemer-v3-utils"
+
+// `BitcoinRedeemerV3` redeems acreBTC for tBTC and hands the tBTC to the tBTC
+// Bridge in a single transaction - unlike `BitcoinRedeemerV2`, it does not wait
+// on the Midas withdrawal queue. That only removes the queue, though: the
+// Bitcoin itself still arrives later, once a tBTC wallet sweeps the redemption
+// and a redemption proof is submitted. So this event is the `Requested` stage
+// only; `Initialized` and `Finalized` come from `tbtc-bridge.ts`, which finds
+// this same log in the transaction receipt to recognise the redemption as
+// Acre's.
+//
+// Not being queued also means there is no request id, so the withdrawal is
+// keyed by the log that created it.
+// eslint-disable-next-line import/prefer-default-export
+export function handleRedemptionRequested(event: RedemptionRequested): void {
+  const ownerEntity = getOrCreateDepositOwner(event.params.owner)
+
+  const withdrawId = buildBitcoinRedeemerV3WithdrawId(
+    event.transaction.hash,
+    event.logIndex,
+  )
+  const withdraw = getOrCreateWithdraw(withdrawId)
+
+  withdraw.depositOwner = ownerEntity.id
+  // `destination` keeps the `Bitcoin` default from `getOrCreateWithdraw`.
+  //
+  // `tbtcAmount` is what acreBTC paid the redeemer, net of the exit fee. The
+  // tBTC Bridge deducts its own treasury and transaction fees on top, so the
+  // Bitcoin the user finally receives is less than this.
+  withdraw.requestedAmount = event.params.tbtcAmount
+  withdraw.amountToRedeem = event.params.tbtcAmount
+
+  const eventEntity = getOrCreateEvent(`${withdrawId}_RedemptionRequested`)
+
+  eventEntity.activity = withdraw.id
+  eventEntity.timestamp = event.block.timestamp
+  eventEntity.type = "Requested"
+
+  ownerEntity.save()
+  withdraw.save()
+  eventEntity.save()
+}

--- a/subgraph/src/midas-redemption-vault.ts
+++ b/subgraph/src/midas-redemption-vault.ts
@@ -1,0 +1,52 @@
+import { log } from "@graphprotocol/graph-ts"
+import { MidasRequestToWithdrawal, Withdraw } from "../generated/schema"
+import { SafeApproveRequest } from "../generated/MidasRedemptionVault/MidasRedemptionVault"
+import { getOrCreateEvent } from "./utils"
+
+// The Midas Vault settles a redemption request asynchronously - anywhere from
+// hours to weeks after it was filed - and pays the tBTC straight to the
+// receiver. None of the Acre contracts are involved, so this event is the only
+// signal that a withdrawal through the `WithdrawalQueue` has completed.
+//
+// Handles both `safeApproveRequest` and `approveRequest`; the two events have
+// the same shape and only differ in whether the operator overrode the rate.
+// eslint-disable-next-line import/prefer-default-export
+export function handleApproveRequest(event: SafeApproveRequest): void {
+  const midasRequestToWithdrawal = MidasRequestToWithdrawal.load(
+    event.params.requestId.toString(),
+  )
+
+  if (!midasRequestToWithdrawal) {
+    // Most of the vault's requests are not Acre's, and the ones that are but
+    // were filed for the Bitcoin path are deliberately not registered - they
+    // complete when the tBTC Bridge delivers the BTC.
+    return
+  }
+
+  // eslint-disable-next-line prefer-destructuring
+  const withdrawId = midasRequestToWithdrawal.withdrawId
+  const withdraw = Withdraw.load(withdrawId)
+
+  if (!withdraw) {
+    // The mapping is only ever written alongside the withdrawal, so this should
+    // be unreachable.
+    log.error("Cannot find withdraw entity with id {}", [withdrawId])
+    return
+  }
+
+  // Midas settles at the rate of the moment, which can differ from the amount
+  // quoted at request time by a wei of rounding. Not worth digging the exact
+  // payout out of the transaction receipt - it is 1e-10 of a satoshi.
+  withdraw.amount = withdraw.amountToRedeem
+
+  const eventEntity = getOrCreateEvent(
+    `${event.transaction.hash.toHexString()}_${withdrawId}_MidasRedeemApproved`,
+  )
+
+  eventEntity.activity = withdraw.id
+  eventEntity.timestamp = event.block.timestamp
+  eventEntity.type = "Finalized"
+
+  withdraw.save()
+  eventEntity.save()
+}

--- a/subgraph/src/tbtc-bridge.ts
+++ b/subgraph/src/tbtc-bridge.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts"
+import { Address, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts"
 import {
   getOrCreateDepositOwner,
   getOrCreateEvent,
@@ -22,27 +22,63 @@ import {
   getTbtcFromRedeemCompletedAndBridgedRequestedLog,
   getRequestIdFromRedeemCompletedAndBridgedRequestedLog,
 } from "./withdrawal-queue-utils"
+import {
+  buildBitcoinRedeemerV3WithdrawId,
+  getBitcoinRedeemerV3RedemptionRequestedLog,
+  getOwnerFromBitcoinRedeemerV3Log,
+  getTbtcAmountFromBitcoinRedeemerV3Log,
+} from "./bitcoin-redeemer-v3-utils"
 import * as BitcoinUtils from "./bitcoin-utils"
 import { RedemptionsCompletedEvent } from "../generated/schema"
 
 export function handleRedemptionRequested(event: RedemptionRequested): void {
-  const withdrawalQueueRedeemCompletedAndBridgedRequestedLog =
-    getRedeemCompletedAndBridgedRequestedLog(
-      (event.receipt as ethereum.TransactionReceipt).logs,
+  // eslint-disable-next-line prefer-destructuring
+  const logs = (event.receipt as ethereum.TransactionReceipt).logs
+
+  // The tBTC Bridge redeems for everyone, so a redemption is only Acre's if the
+  // transaction also carries a log from one of our redemption paths. There are
+  // two, and they cannot both be present:
+  //
+  //  - the Midas `WithdrawalQueue` completing a queued request, where the
+  //    withdrawal was already created at request time and is keyed by the
+  //    queue's request id, and
+  //  - `BitcoinRedeemerV3`, which is not queued, so the redemption is
+  //    requested and handed to the Bridge in this same transaction.
+  let ownerId: Address
+  let withdrawId: string
+  let amount: BigInt
+
+  const redeemCompletedAndBridgeRequestedLog =
+    getRedeemCompletedAndBridgedRequestedLog(logs)
+
+  if (redeemCompletedAndBridgeRequestedLog) {
+    ownerId = getOwnerFromRedeemCompletedAndBridgedRequestedLog(
+      redeemCompletedAndBridgeRequestedLog,
     )
+    withdrawId = getRequestIdFromRedeemCompletedAndBridgedRequestedLog(
+      redeemCompletedAndBridgeRequestedLog,
+    ).toString()
+    amount = getTbtcFromRedeemCompletedAndBridgedRequestedLog(
+      redeemCompletedAndBridgeRequestedLog,
+    )
+  } else {
+    const bitcoinRedeemerV3Log =
+      getBitcoinRedeemerV3RedemptionRequestedLog(logs)
 
-  if (!withdrawalQueueRedeemCompletedAndBridgedRequestedLog) {
-    log.info("The redemption does not come from the Acre", [])
-    return
+    if (!bitcoinRedeemerV3Log) {
+      log.info("The redemption does not come from the Acre", [])
+      return
+    }
+
+    ownerId = getOwnerFromBitcoinRedeemerV3Log(bitcoinRedeemerV3Log)
+    // Must match the id `bitcoin-redeemer-v3.ts` built from the same log, so
+    // this stage lands on the withdrawal that handler already created.
+    withdrawId = buildBitcoinRedeemerV3WithdrawId(
+      event.transaction.hash,
+      bitcoinRedeemerV3Log.logIndex,
+    )
+    amount = getTbtcAmountFromBitcoinRedeemerV3Log(bitcoinRedeemerV3Log)
   }
-
-  const ownerId = getOwnerFromRedeemCompletedAndBridgedRequestedLog(
-    withdrawalQueueRedeemCompletedAndBridgedRequestedLog,
-  )
-
-  const withdrawId = getRequestIdFromRedeemCompletedAndBridgedRequestedLog(
-    withdrawalQueueRedeemCompletedAndBridgedRequestedLog,
-  ).toString()
 
   const ownerEntity = getOrCreateDepositOwner(ownerId)
 
@@ -55,12 +91,8 @@ export function handleRedemptionRequested(event: RedemptionRequested): void {
     getOrCreateRedemptionKeyToPendingWithdrawal(redemptionKey)
   redemptionKeyToPendingWithdrawal.withdrawId = withdrawId
 
-  const withdraw = getOrCreateWithdraw(withdrawId.toString())
+  const withdraw = getOrCreateWithdraw(withdrawId)
   withdraw.depositOwner = ownerEntity.id
-  const amount = getTbtcFromRedeemCompletedAndBridgedRequestedLog(
-    withdrawalQueueRedeemCompletedAndBridgedRequestedLog,
-  )
-
   withdraw.amount = amount
 
   const redemptionRequestedEvent = getOrCreateEvent(

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -11,6 +11,7 @@ import {
   Event,
   Withdraw,
   RedemptionKeyToPendingWithdrawal,
+  MidasRequestToWithdrawal,
 } from "../generated/schema"
 
 export function getOrCreateDepositOwner(depositOwnerId: Address): DepositOwner {
@@ -64,9 +65,30 @@ export function getOrCreateWithdraw(id: string): Withdraw {
   if (!withdraw) {
     withdraw = new Withdraw(id)
     withdraw.depositOwner = Address.zero().toHexString()
+    // Bitcoin is the default so the handlers of the Bitcoin path - which are
+    // spread across `withdrawal-queue.ts` and `tbtc-bridge.ts` and any of which
+    // may be the one that creates the entity - do not have to set it. The tBTC
+    // handlers overwrite it.
+    withdraw.destination = "Bitcoin"
   }
 
   return withdraw
+}
+
+export function getOrCreateMidasRequestToWithdrawal(
+  midasRequestId: BigInt,
+  withdrawId: string,
+): MidasRequestToWithdrawal {
+  const id = midasRequestId.toString()
+  let entity = MidasRequestToWithdrawal.load(id)
+
+  if (!entity) {
+    entity = new MidasRequestToWithdrawal(id)
+  }
+
+  entity.withdrawId = withdrawId
+
+  return entity
 }
 
 export function getLogByEventSignatureInLogs(

--- a/subgraph/src/withdrawal-queue.ts
+++ b/subgraph/src/withdrawal-queue.ts
@@ -1,18 +1,20 @@
-import { log } from "@graphprotocol/graph-ts"
+import { BigInt, log } from "@graphprotocol/graph-ts"
 import { Withdraw } from "../generated/schema"
 import {
   RedeemAndBridgeRequested,
+  RedeemFeeRequested,
+  RedeemRequested,
   RequestRedeemAndBridgeCall,
 } from "../generated/WithdrawalQueue/WithdrawalQueue"
 import {
   getOrCreateDepositOwner,
   getOrCreateEvent,
+  getOrCreateMidasRequestToWithdrawal,
   getOrCreateWithdraw,
 } from "./utils"
 
 // This event is emitted in the same transaction as the `RedemptionRequested`
 // event from the `BitcoinRedeemerV2` contract.
-// eslint-disable-next-line import/prefer-default-export
 export function handleRedeemAndBridgeRequested(
   event: RedeemAndBridgeRequested,
 ): void {
@@ -62,4 +64,68 @@ export function handleRequestRedeemAndBridgeCall(
   withdrawEntity.redeemerOutputScript = redeemerOutputScript
 
   withdrawEntity.save()
+}
+
+// `requestedAmount` is the amount to redeem plus the exit fee, but a redemption
+// to tBTC reports the two in separate events, so each has to add onto whatever
+// the other one already left on the withdrawal. Which of them arrives first
+// does not matter, and the fee event is not emitted at all when the exit fee is
+// zero - as it is on mainnet today.
+function addToRequestedAmount(
+  requestedAmount: BigInt | null,
+  amount: BigInt,
+): BigInt {
+  if (requestedAmount === null) {
+    return amount
+  }
+
+  return requestedAmount.plus(amount)
+}
+
+// Emitted by `WithdrawalQueue.requestRedeem` - a redemption paid out in tBTC to
+// an Ethereum address rather than bridged to Bitcoin. It carries the amounts
+// and the Midas request ID, but the receiver rather than the owner of the
+// shares, so unlike `handleRedeemAndBridgeRequested` above this handler cannot
+// record the withdrawal on its own.
+//
+// The owner comes from `acreBTC.RedemptionRequested`, emitted later in the same
+// transaction, and that is where the `Requested` event is created - see
+// `handleRedemptionRequested` in `acrebtc.ts`. Creating one here as well would
+// leave the withdrawal with two `Requested` events for the one request.
+export function handleRedeemRequested(event: RedeemRequested): void {
+  const withdrawId = event.params.requestId.toString()
+  const withdraw = getOrCreateWithdraw(withdrawId)
+
+  withdraw.destination = "Ethereum"
+  withdraw.amountToRedeem = event.params.tbtcAmount
+  withdraw.requestedAmount = addToRequestedAmount(
+    withdraw.requestedAmount,
+    event.params.tbtcAmount,
+  )
+
+  // Remember which Midas request settles this withdrawal, so the Midas
+  // settlement event can find it. Deliberately only done here: the Bitcoin path
+  // files a Midas request too, but it is not complete until the tBTC Bridge has
+  // delivered the BTC, so it must not be finalized when Midas settles.
+  const midasRequestToWithdrawal = getOrCreateMidasRequestToWithdrawal(
+    event.params.midasRequestId,
+    withdrawId,
+  )
+
+  withdraw.save()
+  midasRequestToWithdrawal.save()
+}
+
+// Emitted by `WithdrawalQueue.requestRedeem` alongside `RedeemRequested`. The
+// exit fee is charged on top of the amount the user receives, so it is part of
+// the requested amount but not of the amount to redeem.
+export function handleRedeemFeeRequested(event: RedeemFeeRequested): void {
+  const withdraw = getOrCreateWithdraw(event.params.requestId.toString())
+
+  withdraw.requestedAmount = addToRequestedAmount(
+    withdraw.requestedAmount,
+    event.params.exitFeeInTbtc,
+  )
+
+  withdraw.save()
 }

--- a/subgraph/subgraph.mainnet.yaml
+++ b/subgraph/subgraph.mainnet.yaml
@@ -76,7 +76,7 @@ dataSources:
         data: "0xe7b8c14cA8Fb4f226C0A3e45e636b84809BB5D06"
       bitcoinRedeemerV3ContractAddress:
         type: Bytes
-        data: "0x0000000000000000000000000000000000000000"
+        data: "0x1Cf54d1dEfe08Ea34A203708d1Fc19c354b9960B"
     source:
       abi: TbtcBridge
       address: "0x5e4861a80B55f035D899f66772117F00FA0E8e7B"
@@ -116,7 +116,7 @@ dataSources:
         data: "0xdF217EFD8f3ecb5E837aedF203C28c1f06854017"
       bitcoinRedeemerV3ContractAddress:
         type: Bytes
-        data: "0x0000000000000000000000000000000000000000"
+        data: "0x1Cf54d1dEfe08Ea34A203708d1Fc19c354b9960B"
     source:
       address: "0x19531C886339dd28b9923d903F6B235C45396ded"
       abi: AcreBTC
@@ -146,9 +146,9 @@ dataSources:
     name: BitcoinRedeemerV3
     network: mainnet
     source:
-      address: "0x0000000000000000000000000000000000000000"
+      address: "0x1Cf54d1dEfe08Ea34A203708d1Fc19c354b9960B"
       abi: BitcoinRedeemerV3
-      startBlock: 23349292
+      startBlock: 25940239
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9

--- a/subgraph/subgraph.mainnet.yaml
+++ b/subgraph/subgraph.mainnet.yaml
@@ -51,6 +51,7 @@ dataSources:
         - Deposit
         - Withdraw
         - Event
+        - MidasRequestToWithdrawal
       abis:
         - name: WithdrawalQueue
           file: ./abis/WithdrawalQueue.json
@@ -58,6 +59,10 @@ dataSources:
         - event: RedeemAndBridgeRequested(indexed uint256,indexed address,indexed uint256,uint256,uint256,uint256)
           handler: handleRedeemAndBridgeRequested
           receipt: true
+        - event: RedeemRequested(indexed uint256,indexed address,indexed uint256,uint256,uint256)
+          handler: handleRedeemRequested
+        - event: RedeemFeeRequested(indexed uint256,indexed uint256,uint256,uint256)
+          handler: handleRedeemFeeRequested
       callHandlers:
         - function: requestRedeemAndBridge(uint256,address,bytes,uint256)
           handler: handleRequestRedeemAndBridgeCall
@@ -69,11 +74,16 @@ dataSources:
       withdrawalQueueContractAddress:
         type: Bytes
         data: "0xe7b8c14cA8Fb4f226C0A3e45e636b84809BB5D06"
+      bitcoinRedeemerV3ContractAddress:
+        type: Bytes
+        data: "0x0000000000000000000000000000000000000000"
     source:
       abi: TbtcBridge
       address: "0x5e4861a80B55f035D899f66772117F00FA0E8e7B"
-      # We can start indexing from the same block where the BitcoinRedeemer
-      # contract was deployed since we only want to index Acre redemptions.
+      # We only want to index Acre redemptions, so this starts at the block the
+      # first Acre redeemer was deployed in. Kept as its own config key: driving
+      # it off a redeemer's `startBlock` means repointing that key at a
+      # redeployed redeemer silently drops every earlier Bitcoin withdrawal.
       startBlock: 23392604
     mapping:
       kind: ethereum/events
@@ -104,6 +114,9 @@ dataSources:
       stbtcContractAddress:
         type: Bytes
         data: "0xdF217EFD8f3ecb5E837aedF203C28c1f06854017"
+      bitcoinRedeemerV3ContractAddress:
+        type: Bytes
+        data: "0x0000000000000000000000000000000000000000"
     source:
       address: "0x19531C886339dd28b9923d903F6B235C45396ded"
       abi: AcreBTC
@@ -115,6 +128,7 @@ dataSources:
       entities:
         - DepositOwner
         - Deposit
+        - Withdraw
         - Event
       abis:
         - name: AcreBTC
@@ -123,4 +137,54 @@ dataSources:
         - event: Deposit(indexed address,indexed address,uint256,uint256)
           handler: handleDeposit
           receipt: true
+        - event: RedemptionRequested(indexed uint256,indexed address,indexed address,address,uint256)
+          handler: handleRedemptionRequested
+        - event: Withdraw(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleWithdraw
       file: ./src/acrebtc.ts
+  - kind: ethereum
+    name: BitcoinRedeemerV3
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: BitcoinRedeemerV3
+      startBlock: 23349292
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - DepositOwner
+        - Withdraw
+        - Event
+      abis:
+        - name: BitcoinRedeemerV3
+          file: ./abis/BitcoinRedeemerV3.json
+      eventHandlers:
+        - event: RedemptionRequested(indexed address,uint256,uint256)
+          handler: handleRedemptionRequested
+      file: ./src/bitcoin-redeemer-v3.ts
+  - kind: ethereum
+    name: MidasRedemptionVault
+    network: mainnet
+    source:
+      address: "0x319a05E260acC2490768A726Ccfd341D4b3D5106"
+      abi: MidasRedemptionVault
+      startBlock: 23392669
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - Withdraw
+        - Event
+        - MidasRequestToWithdrawal
+      abis:
+        - name: MidasRedemptionVault
+          file: ./abis/MidasRedemptionVault.json
+      eventHandlers:
+        - event: SafeApproveRequest(indexed uint256,uint256)
+          handler: handleApproveRequest
+        - event: ApproveRequest(indexed uint256,uint256)
+          handler: handleApproveRequest
+      file: ./src/midas-redemption-vault.ts

--- a/subgraph/subgraph.sepolia.yaml
+++ b/subgraph/subgraph.sepolia.yaml
@@ -51,6 +51,7 @@ dataSources:
         - Deposit
         - Withdraw
         - Event
+        - MidasRequestToWithdrawal
       abis:
         - name: WithdrawalQueue
           file: ./abis/WithdrawalQueue.json
@@ -58,6 +59,10 @@ dataSources:
         - event: RedeemAndBridgeRequested(indexed uint256,indexed address,indexed uint256,uint256,uint256,uint256)
           handler: handleRedeemAndBridgeRequested
           receipt: true
+        - event: RedeemRequested(indexed uint256,indexed address,indexed uint256,uint256,uint256)
+          handler: handleRedeemRequested
+        - event: RedeemFeeRequested(indexed uint256,indexed uint256,uint256,uint256)
+          handler: handleRedeemFeeRequested
       callHandlers:
         - function: requestRedeemAndBridge(uint256,address,bytes,uint256)
           handler: handleRequestRedeemAndBridgeCall
@@ -69,11 +74,16 @@ dataSources:
       withdrawalQueueContractAddress:
         type: Bytes
         data: "0x02BfDaee4FB33a69Ecbf008Ad5822971A5382884"
+      bitcoinRedeemerV3ContractAddress:
+        type: Bytes
+        data: "0x0000000000000000000000000000000000000000"
     source:
       abi: TbtcBridge
       address: "0x9b1a7fE5a16A15F2f9475C5B231750598b113403"
-      # We can start indexing from the same block where the BitcoinRedeemer
-      # contract was deployed since we only want to index Acre redemptions.
+      # We only want to index Acre redemptions, so this starts at the block the
+      # first Acre redeemer was deployed in. Kept as its own config key: driving
+      # it off a redeemer's `startBlock` means repointing that key at a
+      # redeployed redeemer silently drops every earlier Bitcoin withdrawal.
       startBlock: 9169626
     mapping:
       kind: ethereum/events
@@ -104,6 +114,9 @@ dataSources:
       stbtcContractAddress:
         type: Bytes
         data: "0x7e184179b1F95A9ca398E6a16127f06b81Cb37a3"
+      bitcoinRedeemerV3ContractAddress:
+        type: Bytes
+        data: "0x0000000000000000000000000000000000000000"
     source:
       address: "0xB8ba4B007321e0EB4586De49E59593E0eD66d367"
       abi: AcreBTC
@@ -115,6 +128,7 @@ dataSources:
       entities:
         - DepositOwner
         - Deposit
+        - Withdraw
         - Event
       abis:
         - name: AcreBTC
@@ -123,4 +137,54 @@ dataSources:
         - event: Deposit(indexed address,indexed address,uint256,uint256)
           handler: handleDeposit
           receipt: true
+        - event: RedemptionRequested(indexed uint256,indexed address,indexed address,address,uint256)
+          handler: handleRedemptionRequested
+        - event: Withdraw(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleWithdraw
       file: ./src/acrebtc.ts
+  - kind: ethereum
+    name: BitcoinRedeemerV3
+    network: sepolia
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: BitcoinRedeemerV3
+      startBlock: 9190342
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - DepositOwner
+        - Withdraw
+        - Event
+      abis:
+        - name: BitcoinRedeemerV3
+          file: ./abis/BitcoinRedeemerV3.json
+      eventHandlers:
+        - event: RedemptionRequested(indexed address,uint256,uint256)
+          handler: handleRedemptionRequested
+      file: ./src/bitcoin-redeemer-v3.ts
+  - kind: ethereum
+    name: MidasRedemptionVault
+    network: sepolia
+    source:
+      address: "0x6B35F2E4C9D4c1da0eDaf7fd7Dc90D9bCa4b0873"
+      abi: MidasRedemptionVault
+      startBlock: 9169609
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - Withdraw
+        - Event
+        - MidasRequestToWithdrawal
+      abis:
+        - name: MidasRedemptionVault
+          file: ./abis/MidasRedemptionVault.json
+      eventHandlers:
+        - event: SafeApproveRequest(indexed uint256,uint256)
+          handler: handleApproveRequest
+        - event: ApproveRequest(indexed uint256,uint256)
+          handler: handleApproveRequest
+      file: ./src/midas-redemption-vault.ts

--- a/subgraph/subgraph.sepolia.yaml
+++ b/subgraph/subgraph.sepolia.yaml
@@ -76,7 +76,7 @@ dataSources:
         data: "0x02BfDaee4FB33a69Ecbf008Ad5822971A5382884"
       bitcoinRedeemerV3ContractAddress:
         type: Bytes
-        data: "0x0000000000000000000000000000000000000000"
+        data: "0xDCBE41F6dcE0Aca6B7c0e9b68D2D7dD51d9eA8A4"
     source:
       abi: TbtcBridge
       address: "0x9b1a7fE5a16A15F2f9475C5B231750598b113403"
@@ -116,7 +116,7 @@ dataSources:
         data: "0x7e184179b1F95A9ca398E6a16127f06b81Cb37a3"
       bitcoinRedeemerV3ContractAddress:
         type: Bytes
-        data: "0x0000000000000000000000000000000000000000"
+        data: "0xDCBE41F6dcE0Aca6B7c0e9b68D2D7dD51d9eA8A4"
     source:
       address: "0xB8ba4B007321e0EB4586De49E59593E0eD66d367"
       abi: AcreBTC
@@ -146,9 +146,9 @@ dataSources:
     name: BitcoinRedeemerV3
     network: sepolia
     source:
-      address: "0x0000000000000000000000000000000000000000"
+      address: "0xDCBE41F6dcE0Aca6B7c0e9b68D2D7dD51d9eA8A4"
       abi: BitcoinRedeemerV3
-      startBlock: 9190342
+      startBlock: 11667996
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9

--- a/subgraph/subgraph.template.yaml
+++ b/subgraph/subgraph.template.yaml
@@ -51,6 +51,7 @@ dataSources:
         - Deposit
         - Withdraw
         - Event
+        - MidasRequestToWithdrawal
       abis:
         - name: WithdrawalQueue
           file: ./abis/WithdrawalQueue.json
@@ -58,6 +59,10 @@ dataSources:
         - event: RedeemAndBridgeRequested(indexed uint256,indexed address,indexed uint256,uint256,uint256,uint256)
           handler: handleRedeemAndBridgeRequested
           receipt: true
+        - event: RedeemRequested(indexed uint256,indexed address,indexed uint256,uint256,uint256)
+          handler: handleRedeemRequested
+        - event: RedeemFeeRequested(indexed uint256,indexed uint256,uint256,uint256)
+          handler: handleRedeemFeeRequested
       callHandlers:
         - function: requestRedeemAndBridge(uint256,address,bytes,uint256)
           handler: handleRequestRedeemAndBridgeCall
@@ -69,12 +74,17 @@ dataSources:
       withdrawalQueueContractAddress:
         type: Bytes
         data: "{{withdrawalQueue.address}}"
+      bitcoinRedeemerV3ContractAddress:
+        type: Bytes
+        data: "{{bitcoinRedeemerV3.address}}"
     source:
       abi: TbtcBridge
       address: "{{tbtcBridge.address}}"
-      # We can start indexing from the same block where the BitcoinRedeemer
-      # contract was deployed since we only want to index Acre redemptions.
-      startBlock: {{bitcoinRedeemer.startBlock}}
+      # We only want to index Acre redemptions, so this starts at the block the
+      # first Acre redeemer was deployed in. Kept as its own config key: driving
+      # it off a redeemer's `startBlock` means repointing that key at a
+      # redeployed redeemer silently drops every earlier Bitcoin withdrawal.
+      startBlock: {{tbtcBridge.startBlock}}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -104,6 +114,9 @@ dataSources:
       stbtcContractAddress:
         type: Bytes
         data: "{{stbtc.address}}"
+      bitcoinRedeemerV3ContractAddress:
+        type: Bytes
+        data: "{{bitcoinRedeemerV3.address}}"
     source:
       address: "{{acrebtc.address}}"
       abi: AcreBTC
@@ -115,6 +128,7 @@ dataSources:
       entities:
         - DepositOwner
         - Deposit
+        - Withdraw
         - Event
       abis:
         - name: AcreBTC
@@ -123,4 +137,54 @@ dataSources:
         - event: Deposit(indexed address,indexed address,uint256,uint256)
           handler: handleDeposit
           receipt: true
+        - event: RedemptionRequested(indexed uint256,indexed address,indexed address,address,uint256)
+          handler: handleRedemptionRequested
+        - event: Withdraw(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleWithdraw
       file: ./src/acrebtc.ts
+  - kind: ethereum
+    name: BitcoinRedeemerV3
+    network: {{network}}
+    source:
+      address: "{{bitcoinRedeemerV3.address}}"
+      abi: BitcoinRedeemerV3
+      startBlock: {{bitcoinRedeemerV3.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - DepositOwner
+        - Withdraw
+        - Event
+      abis:
+        - name: BitcoinRedeemerV3
+          file: ./abis/BitcoinRedeemerV3.json
+      eventHandlers:
+        - event: RedemptionRequested(indexed address,uint256,uint256)
+          handler: handleRedemptionRequested
+      file: ./src/bitcoin-redeemer-v3.ts
+  - kind: ethereum
+    name: MidasRedemptionVault
+    network: {{network}}
+    source:
+      address: "{{midasRedemptionVault.address}}"
+      abi: MidasRedemptionVault
+      startBlock: {{midasRedemptionVault.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - Withdraw
+        - Event
+        - MidasRequestToWithdrawal
+      abis:
+        - name: MidasRedemptionVault
+          file: ./abis/MidasRedemptionVault.json
+      eventHandlers:
+        - event: SafeApproveRequest(indexed uint256,uint256)
+          handler: handleApproveRequest
+        - event: ApproveRequest(indexed uint256,uint256)
+          handler: handleApproveRequest
+      file: ./src/midas-redemption-vault.ts

--- a/subgraph/tests/acrebtc-utils.ts
+++ b/subgraph/tests/acrebtc-utils.ts
@@ -1,10 +1,20 @@
 import { ethereum, BigInt, Address, Bytes } from "@graphprotocol/graph-ts"
 import { newMockEvent } from "matchstick-as/assembly/defaults"
-import { Deposit } from "../generated/AcreBTC/AcreBTC"
+import {
+  Deposit,
+  RedemptionRequested,
+  Withdraw,
+} from "../generated/AcreBTC/AcreBTC"
 
 let mockEventCounter = 0
 
-// eslint-disable-next-line import/prefer-default-export
+function nextTransactionHash(): Bytes {
+  mockEventCounter += 1
+  return Bytes.fromHexString(
+    `0x${mockEventCounter.toString(16).padStart(64, "0")}`,
+  )
+}
+
 export function createDepositEvent(
   sender: Address,
   owner: Address,
@@ -12,12 +22,9 @@ export function createDepositEvent(
   shares: BigInt,
 ): Deposit {
   const depositEvent = changetype<Deposit>(newMockEvent())
-  mockEventCounter += 1
 
   depositEvent.parameters = []
-  depositEvent.transaction.hash = Bytes.fromHexString(
-    `0x${mockEventCounter.toString(16).padStart(64, "0")}`,
-  )
+  depositEvent.transaction.hash = nextTransactionHash()
 
   const senderParam = new ethereum.EventParam(
     "sender",
@@ -45,4 +52,78 @@ export function createDepositEvent(
   depositEvent.parameters.push(sharesParam)
 
   return depositEvent
+}
+
+export function createRedemptionRequestedEvent(
+  requestId: BigInt,
+  owner: Address,
+  receiver: Address,
+  caller: Address,
+  shares: BigInt,
+): RedemptionRequested {
+  const event = changetype<RedemptionRequested>(newMockEvent())
+
+  event.parameters = []
+  event.transaction.hash = nextTransactionHash()
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      "requestId",
+      ethereum.Value.fromUnsignedBigInt(requestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam("caller", ethereum.Value.fromAddress(caller)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  )
+
+  return event
+}
+
+export function createWithdrawEvent(
+  sender: Address,
+  receiver: Address,
+  owner: Address,
+  assets: BigInt,
+  shares: BigInt,
+): Withdraw {
+  const event = changetype<Withdraw>(newMockEvent())
+
+  event.parameters = []
+  event.transaction.hash = nextTransactionHash()
+
+  event.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "assets",
+      ethereum.Value.fromUnsignedBigInt(assets),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  )
+
+  return event
 }

--- a/subgraph/tests/bitcoin-redeemer-v3-utils.ts
+++ b/subgraph/tests/bitcoin-redeemer-v3-utils.ts
@@ -1,0 +1,82 @@
+import {
+  ethereum,
+  BigInt,
+  Address,
+  Bytes,
+  ByteArray,
+  crypto,
+  Wrapped,
+} from "@graphprotocol/graph-ts"
+import { newMockEvent } from "matchstick-as/assembly/defaults"
+import { RedemptionRequested } from "../generated/BitcoinRedeemerV3/BitcoinRedeemerV3"
+import { bigIntTo64HexString } from "../src/utils"
+
+export function createRedemptionRequestedEvent(
+  owner: Address,
+  shares: BigInt,
+  tbtcAmount: BigInt,
+  transactionHash: Bytes,
+  logIndex: BigInt,
+): RedemptionRequested {
+  const event = changetype<RedemptionRequested>(newMockEvent())
+
+  event.parameters = []
+  event.transaction.hash = transactionHash
+  event.logIndex = logIndex
+
+  event.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "tbtcAmount",
+      ethereum.Value.fromUnsignedBigInt(tbtcAmount),
+    ),
+  )
+
+  return event
+}
+
+// `RedemptionRequested(address,uint256,uint256)` - shared verbatim with
+// `BitcoinRedeemerV2`, which is exactly why the emitter address matters.
+export function buildRedemptionRequestedLog(
+  emitter: Address,
+  owner: Address,
+  shares: BigInt,
+  tbtcAmount: BigInt,
+  transactionHash: Bytes,
+  logIndex: BigInt,
+): ethereum.Log {
+  return new ethereum.Log(
+    emitter,
+    [
+      Bytes.fromByteArray(
+        crypto.keccak256(
+          ByteArray.fromUTF8("RedemptionRequested(address,uint256,uint256)"),
+        ),
+      ),
+      Bytes.fromHexString(
+        `0x000000000000000000000000${owner.toHexString().slice(2)}`,
+      ),
+    ],
+    Bytes.fromHexString(
+      bigIntTo64HexString(shares).concat(
+        bigIntTo64HexString(tbtcAmount).slice(2),
+      ),
+    ),
+    Bytes.fromI32(1),
+    Bytes.fromI32(1),
+    transactionHash,
+    BigInt.fromI32(0),
+    logIndex,
+    BigInt.fromI32(0),
+    "log",
+    new Wrapped(false),
+  )
+}

--- a/subgraph/tests/midas-redemption-vault-utils.ts
+++ b/subgraph/tests/midas-redemption-vault-utils.ts
@@ -1,0 +1,30 @@
+import { ethereum, BigInt, Bytes } from "@graphprotocol/graph-ts"
+import { newMockEvent } from "matchstick-as/assembly/defaults"
+import { SafeApproveRequest } from "../generated/MidasRedemptionVault/MidasRedemptionVault"
+
+// eslint-disable-next-line import/prefer-default-export
+export function createSafeApproveRequestEvent(
+  requestId: BigInt,
+  newOutRate: BigInt,
+  transactionHash: Bytes,
+): SafeApproveRequest {
+  const event = changetype<SafeApproveRequest>(newMockEvent())
+
+  event.parameters = []
+  event.transaction.hash = transactionHash
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      "requestId",
+      ethereum.Value.fromUnsignedBigInt(requestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "newOutRate",
+      ethereum.Value.fromUnsignedBigInt(newOutRate),
+    ),
+  )
+
+  return event
+}

--- a/subgraph/tests/tbtc-bridge-utils.ts
+++ b/subgraph/tests/tbtc-bridge-utils.ts
@@ -37,7 +37,6 @@ class RedemptionRequestedEventData {
   }
 }
 
-// eslint-disable-next-line import/prefer-default-export
 export function createRedemptionRequestedEvent(
   withdrawId: BigInt,
 ): RedemptionRequestedEventData {
@@ -150,4 +149,30 @@ export function createRedemptionRequestedEvent(
   )
 
   return data
+}
+
+// The unqueued path: the Bridge event arrives with a `BitcoinRedeemerV3` log
+// in the receipt rather than a `WithdrawalQueue` one. Everything else about the
+// Bridge event is identical, which is the point - the emitter of the redeemer
+// log is the only thing that tells the two paths apart.
+export function attachRedemptionRequestedLogToReceipt(
+  event: RedemptionRequested,
+  log: ethereum.Log,
+): RedemptionRequested {
+  ;(event.receipt as ethereum.TransactionReceipt).logs.push(log)
+
+  return event
+}
+
+export function createBareRedemptionRequestedEvent(): RedemptionRequested {
+  const data = createRedemptionRequestedEvent(BigInt.fromI32(1))
+  // eslint-disable-next-line prefer-destructuring
+  const event = data.event
+
+  // Drop the WithdrawalQueue log the helper attached, so only the redeemer log
+  // is left to identify the redemption.
+  const receipt = event.receipt as ethereum.TransactionReceipt
+  receipt.logs.length = 0
+
+  return event
 }

--- a/subgraph/tests/tbtc-bridge.test.ts
+++ b/subgraph/tests/tbtc-bridge.test.ts
@@ -8,15 +8,36 @@ import {
   dataSourceMock,
 } from "matchstick-as/assembly/index"
 
-import { DataSourceContext, Bytes, BigInt } from "@graphprotocol/graph-ts"
-import { createRedemptionRequestedEvent } from "./tbtc-bridge-utils"
+import {
+  DataSourceContext,
+  Bytes,
+  BigInt,
+  Address,
+} from "@graphprotocol/graph-ts"
+import {
+  attachRedemptionRequestedLogToReceipt,
+  createBareRedemptionRequestedEvent,
+  createRedemptionRequestedEvent,
+} from "./tbtc-bridge-utils"
+import {
+  buildRedemptionRequestedLog,
+  createRedemptionRequestedEvent as createV3RedemptionRequestedEvent,
+} from "./bitcoin-redeemer-v3-utils"
 import { handleRedemptionRequested } from "../src/tbtc-bridge"
+import { handleRedemptionRequested as handleV3RedemptionRequested } from "../src/bitcoin-redeemer-v3"
 
 // Set up context
 const context = new DataSourceContext()
 context.setBytes(
   "withdrawalQueueContractAddress",
   Bytes.fromHexString("0xa7049b83dB603f4a7FE93B29D2DfEa76065e76E8"),
+)
+const bitcoinRedeemerV3ContractAddress = Address.fromString(
+  "0xE1d25025835A89C93d56a029C80699BE056584d2",
+)
+context.setBytes(
+  "bitcoinRedeemerV3ContractAddress",
+  Bytes.fromHexString(bitcoinRedeemerV3ContractAddress.toHexString()),
 )
 
 dataSourceMock.setReturnValues(
@@ -106,6 +127,151 @@ describe("handleRedemptionRequested", () => {
       )
 
       assert.fieldEquals("Event", eventId, "type", "Initialized")
+    })
+  })
+})
+
+// --- the unqueued BitcoinRedeemerV3 path -----------------------------------
+//
+// Same tBTC Bridge event, but the receipt carries a `BitcoinRedeemerV3` log
+// instead of a `WithdrawalQueue` one. `BitcoinRedeemerV2` declares an event of
+// the same name and the same canonical signature, so the emitter address is the
+// only thing that distinguishes them - hence the negative case below.
+const v3Owner = Address.fromString("0x000000000000000000000000000000000000dEaD")
+const v3Shares = BigInt.fromI32(900)
+const v3TbtcAmount = BigInt.fromI32(990)
+const v3LogIndex = BigInt.fromI32(7)
+
+const v3BridgeEvent = createBareRedemptionRequestedEvent()
+const v3WithdrawId = `${v3BridgeEvent.transaction.hash.toHexString()}_${v3LogIndex.toString()}`
+
+attachRedemptionRequestedLogToReceipt(
+  v3BridgeEvent,
+  buildRedemptionRequestedLog(
+    bitcoinRedeemerV3ContractAddress,
+    v3Owner,
+    v3Shares,
+    v3TbtcAmount,
+    v3BridgeEvent.transaction.hash,
+    v3LogIndex,
+  ),
+)
+
+const v2BridgeEvent = createBareRedemptionRequestedEvent()
+attachRedemptionRequestedLogToReceipt(
+  v2BridgeEvent,
+  buildRedemptionRequestedLog(
+    // BitcoinRedeemerV2 - a different address, identical event topic.
+    Address.fromString("0x42A5f91586DDf041A6084494B0b375CdA34d55e9"),
+    v3Owner,
+    v3Shares,
+    v3TbtcAmount,
+    v2BridgeEvent.transaction.hash,
+    v3LogIndex,
+  ),
+)
+
+// The load-bearing invariant of this path: `bitcoin-redeemer-v3.ts`
+// and `tbtc-bridge.ts` derive the withdrawal id from the same log, so the two
+// stages have to land on one entity rather than two.
+const v3RedeemerEvent = createV3RedemptionRequestedEvent(
+  v3Owner,
+  v3Shares,
+  v3TbtcAmount,
+  v3BridgeEvent.transaction.hash,
+  v3LogIndex,
+)
+
+describe("handleRedemptionRequested for BitcoinRedeemerV3", () => {
+  describe("when both stages of the same redemption are indexed", () => {
+    beforeAll(() => {
+      handleV3RedemptionRequested(v3RedeemerEvent)
+      handleRedemptionRequested(v3BridgeEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should produce exactly one withdrawal, not two", () => {
+      assert.entityCount("Withdraw", 1)
+      assert.fieldEquals("Withdraw", v3WithdrawId, "destination", "Bitcoin")
+    })
+
+    test("should carry both the requested and the initialized event", () => {
+      assert.entityCount("Event", 2)
+      assert.fieldEquals(
+        "Event",
+        `${v3WithdrawId}_RedemptionRequested`,
+        "type",
+        "Requested",
+      )
+      assert.fieldEquals(
+        "Event",
+        `${v3BridgeEvent.transaction.hash.toHexString()}_RedemptionRequested`,
+        "type",
+        "Initialized",
+      )
+    })
+  })
+
+  describe("when the receipt carries a BitcoinRedeemerV3 log", () => {
+    beforeAll(() => {
+      handleRedemptionRequested(v3BridgeEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should attribute the withdrawal to the acreBTC share owner", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        v3WithdrawId,
+        "depositOwner",
+        v3Owner.toHexString(),
+      )
+    })
+
+    test("should key it the same way the redeemer handler does", () => {
+      assert.entityCount("Withdraw", 1)
+    })
+
+    test("should set the bridged amount", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        v3WithdrawId,
+        "amount",
+        v3TbtcAmount.toString(),
+      )
+    })
+
+    test("should mark the redemption as initialized", () => {
+      assert.fieldEquals(
+        "Event",
+        `${v3BridgeEvent.transaction.hash.toHexString()}_RedemptionRequested`,
+        "type",
+        "Initialized",
+      )
+    })
+
+    test("should register the redemption key so the proof can finalize it", () => {
+      assert.entityCount("RedemptionKeyToPendingWithdrawal", 1)
+    })
+  })
+
+  describe("when the redeemer log comes from BitcoinRedeemerV2", () => {
+    beforeAll(() => {
+      handleRedemptionRequested(v2BridgeEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should not be treated as an Acre redemption", () => {
+      assert.entityCount("Withdraw", 0)
+      assert.entityCount("Event", 0)
     })
   })
 })

--- a/subgraph/tests/tbtc-withdrawal.test.ts
+++ b/subgraph/tests/tbtc-withdrawal.test.ts
@@ -1,0 +1,425 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  beforeAll,
+  afterAll,
+  dataSourceMock,
+} from "matchstick-as/assembly/index"
+import {
+  BigInt,
+  Address,
+  Bytes,
+  DataSourceContext,
+} from "@graphprotocol/graph-ts"
+import {
+  createRedeemAndBridgeRequestedEvent,
+  createRedeemFeeRequestedEvent,
+  createRedeemRequestedEvent,
+} from "./withdrawal-queue-utils"
+import {
+  createRedemptionRequestedEvent,
+  createWithdrawEvent,
+} from "./acrebtc-utils"
+import { createSafeApproveRequestEvent } from "./midas-redemption-vault-utils"
+import { createRedemptionRequestedEvent as createV3RedemptionRequestedEvent } from "./bitcoin-redeemer-v3-utils"
+import {
+  handleRedeemAndBridgeRequested,
+  handleRedeemFeeRequested,
+  handleRedeemRequested,
+} from "../src/withdrawal-queue"
+import { handleRedemptionRequested, handleWithdraw } from "../src/acrebtc"
+import { handleApproveRequest } from "../src/midas-redemption-vault"
+import { handleRedemptionRequested as handleV3RedemptionRequested } from "../src/bitcoin-redeemer-v3"
+
+// Contracts
+const acrebtcContractAddress = "0xB8ba4B007321e0EB4586De49E59593E0eD66d367"
+const stbtcContractAddress = Address.fromString(
+  "0x7e184179b1F95A9ca398E6a16127f06b81Cb37a3",
+)
+const bitcoinRedeemerV3ContractAddress = Address.fromString(
+  "0xE1d25025835A89C93d56a029C80699BE056584d2",
+)
+
+// Accounts
+const owner = Address.fromString("0x0000000000000000000000000000000000000001")
+const receiver = Address.fromString(
+  "0x0000000000000000000000000000000000000002",
+)
+
+const context = new DataSourceContext()
+context.setBytes(
+  "stbtcContractAddress",
+  Bytes.fromHexString(stbtcContractAddress.toHexString()),
+)
+context.setBytes(
+  "bitcoinRedeemerV3ContractAddress",
+  Bytes.fromHexString(bitcoinRedeemerV3ContractAddress.toHexString()),
+)
+
+dataSourceMock.setReturnValues(acrebtcContractAddress, "sepolia", context)
+
+// A withdrawal through the queue. Mirrors mainnet request 102 in shape: the
+// queue request id and the Midas request id are unrelated counters.
+const requestId = BigInt.fromI32(102)
+const midasRequestId = BigInt.fromI32(116)
+const tbtcAmount = BigInt.fromI32(1000)
+const exitFeeInTbtc = BigInt.fromI32(25)
+const midasShares = BigInt.fromI32(880)
+const shares = BigInt.fromI32(900)
+
+const redeemFeeRequestedEvent = createRedeemFeeRequestedEvent(
+  requestId,
+  BigInt.fromI32(117),
+  exitFeeInTbtc,
+  BigInt.fromI32(20),
+)
+const redeemRequestedEvent = createRedeemRequestedEvent(
+  requestId,
+  receiver,
+  midasRequestId,
+  tbtcAmount,
+  midasShares,
+)
+const redemptionRequestedEvent = createRedemptionRequestedEvent(
+  requestId,
+  owner,
+  receiver,
+  owner,
+  shares,
+)
+const requestedEventId = `${redemptionRequestedEvent.transaction.hash.toHexString()}_${requestId.toString()}_RedemptionRequested`
+
+const settlementTransactionHash = Bytes.fromHexString(
+  "0xb383989d30c935ae3d01be27e6be33b48a35ac794e7931cf06c9f28b38f7266c",
+)
+const safeApproveRequestEvent = createSafeApproveRequestEvent(
+  midasRequestId,
+  BigInt.fromI32(1),
+  settlementTransactionHash,
+)
+const finalizedEventId = `${settlementTransactionHash.toHexString()}_${requestId.toString()}_MidasRedeemApproved`
+
+const unrelatedSafeApproveRequestEvent = createSafeApproveRequestEvent(
+  BigInt.fromI32(999),
+  BigInt.fromI32(1),
+  Bytes.fromHexString(`0x${"11".repeat(32)}`),
+)
+
+const redeemAndBridgeRequestedEvent = createRedeemAndBridgeRequestedEvent(
+  requestId,
+  owner,
+  midasRequestId,
+  tbtcAmount,
+  exitFeeInTbtc,
+  midasShares,
+)
+
+// A withdrawal straight from acreBTC. This one really does complete in a
+// single transaction - the tBTC lands in the receiver's wallet there and then.
+const assets = BigInt.fromI32(1000)
+const withdrawEvent = createWithdrawEvent(
+  owner,
+  receiver,
+  owner,
+  assets,
+  shares,
+)
+const withdrawId = `${withdrawEvent.transaction.hash.toHexString()}_${withdrawEvent.logIndex.toString()}`
+// BitcoinRedeemerV3 redeems the shares to itself before bridging them.
+const redeemerV3WithdrawEvent = createWithdrawEvent(
+  bitcoinRedeemerV3ContractAddress,
+  bitcoinRedeemerV3ContractAddress,
+  owner,
+  assets,
+  shares,
+)
+
+const v3TbtcAmount = BigInt.fromI32(990)
+const v3TransactionHash = Bytes.fromHexString(`0x${"22".repeat(32)}`)
+const v3LogIndex = BigInt.fromI32(3)
+const v3RedemptionRequestedEvent = createV3RedemptionRequestedEvent(
+  owner,
+  shares,
+  v3TbtcAmount,
+  v3TransactionHash,
+  v3LogIndex,
+)
+const v3WithdrawId = `${v3TransactionHash.toHexString()}_${v3LogIndex.toString()}`
+
+function handleRedeemRequest(): void {
+  // The contract emits in this order within a single transaction.
+  handleRedeemFeeRequested(redeemFeeRequestedEvent)
+  handleRedeemRequested(redeemRequestedEvent)
+  handleRedemptionRequested(redemptionRequestedEvent)
+}
+
+describe("withdrawal to tBTC through the withdrawal queue", () => {
+  describe("when the redemption has been requested", () => {
+    beforeAll(() => {
+      handleRedeemRequest()
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should create a withdrawal owned by the acreBTC share owner", () => {
+      assert.entityCount("Withdraw", 1)
+      assert.fieldEquals(
+        "Withdraw",
+        requestId.toString(),
+        "depositOwner",
+        owner.toHexString(),
+      )
+    })
+
+    test("should mark the withdrawal as going to Ethereum", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        requestId.toString(),
+        "destination",
+        "Ethereum",
+      )
+    })
+
+    test("should keep the exit fee out of the amount to redeem", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        requestId.toString(),
+        "amountToRedeem",
+        tbtcAmount.toString(),
+      )
+      assert.fieldEquals(
+        "Withdraw",
+        requestId.toString(),
+        "requestedAmount",
+        tbtcAmount.plus(exitFeeInTbtc).toString(),
+      )
+    })
+
+    test("should create exactly one requested event", () => {
+      assert.entityCount("Event", 1)
+      assert.fieldEquals("Event", requestedEventId, "type", "Requested")
+    })
+
+    test("should remember which Midas request settles the withdrawal", () => {
+      assert.fieldEquals(
+        "MidasRequestToWithdrawal",
+        midasRequestId.toString(),
+        "withdrawId",
+        requestId.toString(),
+      )
+    })
+  })
+
+  describe("when the Midas vault settles the request", () => {
+    beforeAll(() => {
+      handleRedeemRequest()
+      handleApproveRequest(safeApproveRequestEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should finalize the withdrawal", () => {
+      assert.entityCount("Event", 2)
+      assert.fieldEquals("Event", finalizedEventId, "type", "Finalized")
+    })
+
+    test("should set the redeemed amount", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        requestId.toString(),
+        "amount",
+        tbtcAmount.toString(),
+      )
+    })
+  })
+
+  describe("when the settled Midas request is not ours", () => {
+    beforeAll(() => {
+      handleApproveRequest(unrelatedSafeApproveRequestEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should not create anything", () => {
+      assert.entityCount("Withdraw", 0)
+      assert.entityCount("Event", 0)
+    })
+  })
+
+  describe("when the redemption is bridged to Bitcoin instead", () => {
+    beforeAll(() => {
+      handleRedeemAndBridgeRequested(redeemAndBridgeRequestedEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should mark the withdrawal as going to Bitcoin", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        requestId.toString(),
+        "destination",
+        "Bitcoin",
+      )
+    })
+
+    test("should not register the Midas request, so Midas cannot finalize it", () => {
+      assert.entityCount("MidasRequestToWithdrawal", 0)
+    })
+  })
+})
+
+describe("withdrawal to tBTC directly from acreBTC", () => {
+  describe("when the receiver is an Ethereum address", () => {
+    beforeAll(() => {
+      handleWithdraw(withdrawEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should create a withdrawal owned by the acreBTC share owner", () => {
+      assert.entityCount("Withdraw", 1)
+      assert.fieldEquals(
+        "Withdraw",
+        withdrawId,
+        "depositOwner",
+        owner.toHexString(),
+      )
+    })
+
+    test("should mark the withdrawal as going to Ethereum", () => {
+      assert.fieldEquals("Withdraw", withdrawId, "destination", "Ethereum")
+    })
+
+    test("should set all amounts to the redeemed assets", () => {
+      assert.fieldEquals("Withdraw", withdrawId, "amount", assets.toString())
+      assert.fieldEquals(
+        "Withdraw",
+        withdrawId,
+        "amountToRedeem",
+        assets.toString(),
+      )
+      assert.fieldEquals(
+        "Withdraw",
+        withdrawId,
+        "requestedAmount",
+        assets.toString(),
+      )
+    })
+
+    test("should request and finalize in the same transaction", () => {
+      assert.entityCount("Event", 2)
+      assert.fieldEquals(
+        "Event",
+        `${withdrawId}_WithdrawRequested`,
+        "type",
+        "Requested",
+      )
+      assert.fieldEquals(
+        "Event",
+        `${withdrawId}_WithdrawFinalized`,
+        "type",
+        "Finalized",
+      )
+    })
+  })
+
+  describe("when the receiver is the Bitcoin redeemer", () => {
+    beforeAll(() => {
+      handleWithdraw(redeemerV3WithdrawEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should not record it as a withdrawal to tBTC", () => {
+      assert.entityCount("Withdraw", 0)
+      assert.entityCount("Event", 0)
+    })
+  })
+})
+
+// --- Bitcoin withdrawal through BitcoinRedeemerV3 --------------------------
+//
+// Not queued, unlike `BitcoinRedeemerV2`: the redeem and the hand-off to the
+// tBTC Bridge both happen in the request transaction, so `Requested` and
+// `Initialized` land together. The Bitcoin is still not delivered at that
+// point - `Finalized` only arrives with the redemption proof, hours later.
+describe("withdrawal to BTC through BitcoinRedeemerV3", () => {
+  describe("when the redemption is requested", () => {
+    beforeAll(() => {
+      handleV3RedemptionRequested(v3RedemptionRequestedEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should create a withdrawal owned by the acreBTC share owner", () => {
+      assert.entityCount("Withdraw", 1)
+      assert.fieldEquals(
+        "Withdraw",
+        v3WithdrawId,
+        "depositOwner",
+        owner.toHexString(),
+      )
+    })
+
+    test("should mark the withdrawal as going to Bitcoin", () => {
+      assert.fieldEquals("Withdraw", v3WithdrawId, "destination", "Bitcoin")
+    })
+
+    test("should set the amounts from the bridged tBTC", () => {
+      assert.fieldEquals(
+        "Withdraw",
+        v3WithdrawId,
+        "amountToRedeem",
+        v3TbtcAmount.toString(),
+      )
+      assert.fieldEquals(
+        "Withdraw",
+        v3WithdrawId,
+        "requestedAmount",
+        v3TbtcAmount.toString(),
+      )
+    })
+
+    test("should create a single requested event", () => {
+      assert.entityCount("Event", 1)
+      assert.fieldEquals(
+        "Event",
+        `${v3WithdrawId}_RedemptionRequested`,
+        "type",
+        "Requested",
+      )
+    })
+  })
+
+  describe("when acreBTC reports the redeem to the redeemer", () => {
+    beforeAll(() => {
+      handleV3RedemptionRequested(v3RedemptionRequestedEvent)
+      handleWithdraw(redeemerV3WithdrawEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("should not add a second withdrawal for the same redemption", () => {
+      assert.entityCount("Withdraw", 1)
+      assert.fieldEquals("Withdraw", v3WithdrawId, "destination", "Bitcoin")
+    })
+  })
+})

--- a/subgraph/tests/withdrawal-queue-utils.ts
+++ b/subgraph/tests/withdrawal-queue-utils.ts
@@ -5,6 +5,8 @@ import {
 } from "matchstick-as/assembly/defaults"
 import {
   RedeemAndBridgeRequested,
+  RedeemFeeRequested,
+  RedeemRequested,
   RequestRedeemAndBridgeCall,
 } from "../generated/WithdrawalQueue/WithdrawalQueue"
 
@@ -95,4 +97,84 @@ export function createRequestRedeemAndBridgeCall(
       ],
     ),
   )
+}
+
+export function createRedeemRequestedEvent(
+  requestId: BigInt,
+  receiver: Address,
+  midasRequestId: BigInt,
+  tbtcAmount: BigInt,
+  midasShares: BigInt,
+): RedeemRequested {
+  const event = changetype<RedeemRequested>(newMockEvent())
+
+  event.parameters = []
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      "requestId",
+      ethereum.Value.fromUnsignedBigInt(requestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "midasRequestId",
+      ethereum.Value.fromUnsignedBigInt(midasRequestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "tbtcAmount",
+      ethereum.Value.fromUnsignedBigInt(tbtcAmount),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "midasShares",
+      ethereum.Value.fromUnsignedBigInt(midasShares),
+    ),
+  )
+
+  return event
+}
+
+export function createRedeemFeeRequestedEvent(
+  requestId: BigInt,
+  midasRequestId: BigInt,
+  exitFeeInTbtc: BigInt,
+  exitFeeInMidasShares: BigInt,
+): RedeemFeeRequested {
+  const event = changetype<RedeemFeeRequested>(newMockEvent())
+
+  event.parameters = []
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      "requestId",
+      ethereum.Value.fromUnsignedBigInt(requestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "midasRequestId",
+      ethereum.Value.fromUnsignedBigInt(midasRequestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "exitFeeInTbtc",
+      ethereum.Value.fromUnsignedBigInt(exitFeeInTbtc),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "exitFeeInMidasShares",
+      ethereum.Value.fromUnsignedBigInt(exitFeeInMidasShares),
+    ),
+  )
+
+  return event
 }


### PR DESCRIPTION
Until now the subgraph only indexed withdrawals that go to Bitcoin. A withdrawal paid out in tBTC showed up in the dapp right after signing and then disappeared on the next refetch, because nothing was indexing it. There are already 23 of them on mainnet.
  
## What changed

### Subgraph
- Index both tBTC payout paths: a queued redemption (acreBTC.RedemptionRequested) and a direct redeem when the queue is unset (the ERC4626 Withdraw event). Amounts come from the queue's RedeemRequested / RedeemFeeRequested.
- A queued redemption is only complete once Midas settles, and nothing on the Acre side fires then, so completion comes from the Midas redemption vault's SafeApproveRequest. The new MidasRequestToWithdrawal entity remembers which withdrawal filed which Midas request.
- Index BitcoinRedeemerV3. It is not queued, so it also emits Withdraw, which would otherwise be recorded as a finished tBTC withdrawal. It is now recognised as a Bitcoin withdrawal instead.
- Withdraw gains a destination field (Bitcoin or Ethereum), defaulting to Bitcoin so nothing existing changes.
- tbtcBridge gets its own startBlock instead of borrowing the redeemer's, so repointing a redeemer can no longer truncate the Bridge's indexing range.

### SDK
- Pass the destination through, and read withdrawal events by type instead of by position. tBTC withdrawals never touch the tBTC Bridge, so they have no Initialized stage and positional reads made every settled one look pending.

### dapp
- Withdrawals to tBTC show a tBTC on Ethereum tag and link to Etherscan. Before, every withdrawal looked the same and the Details link always pointed at a Bitcoin explorer, which resolves to nothing for a tBTC withdrawal.

- The withdraw amount field is locked to the whole position. It was already seeded with the full balance and a withdrawal exits the whole position, so any other amount the user typed could not be acted on.

### Deployment
The subgraphs are deployed on both mainnet and testnet (Sepolia), with the `MidasRedemptionVault` and `BitcoinRedeemerV3` addresses filled in.